### PR TITLE
공통 응답 명세

### DIFF
--- a/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
+++ b/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
@@ -2,6 +2,10 @@ package camp.woowak.lab.web.api.utils;
 
 import org.springframework.http.HttpStatus;
 
+/**
+ * APIResponse를 Jackson의 ObjectMapper와 함께 사용하려면,
+ * Generic Type의 {@code data}에는 Getter 메서드가 필요합니다.
+ */
 public class APIResponse<T> {
 	private final T data;
 	private final int status;

--- a/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
+++ b/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
@@ -1,0 +1,21 @@
+package camp.woowak.lab.web.api.utils;
+
+import org.springframework.http.HttpStatus;
+
+public class APIResponse<T> {
+	private final T data;
+	private final int status;
+
+	APIResponse(final HttpStatus status, final T data) {
+		this.data = data;
+		this.status = status.value();
+	}
+
+	public T getData() {
+		return data;
+	}
+
+	public int getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/api/utils/APIUtils.java
+++ b/src/main/java/camp/woowak/lab/web/api/utils/APIUtils.java
@@ -1,0 +1,19 @@
+package camp.woowak.lab.web.api.utils;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ *
+ * API Utils
+ * of Method는 status와 data를 이용해 APIResponse객체를 만들 수 있습니다.
+ *
+ */
+public final class APIUtils {
+	private APIUtils() {
+	}
+
+	public static <T> ResponseEntity<APIResponse<T>> of(HttpStatus status, T data) {
+		return new ResponseEntity<>(new APIResponse<>(status, data), status);
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/api/utils/APIUtilsTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/utils/APIUtilsTest.java
@@ -1,0 +1,73 @@
+package camp.woowak.lab.web.api.utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+@DisplayName("APIUtils 클래스")
+class APIUtilsTest {
+	@Nested
+	@DisplayName("of메서드의")
+	class OfTest {
+		@Nested
+		@DisplayName("HttpStatus 값과 Data를 파라미터로 받는 메서드는")
+		class ParamWithHttpStatusAndData {
+			@Test
+			@DisplayName("data와 status를 가지는 APIResponse를 생성할 수 있다.")
+			void APIResponseWithHttpStatusAndData() throws JsonProcessingException {
+				//given
+				HttpStatus status = HttpStatus.OK;
+				String message = "hello world";
+
+				//when
+				ResponseEntity<APIResponse<String>> apiResponse = APIUtils.of(status, message);
+
+				//then
+				assertThat(apiResponse.getStatusCode()).isEqualTo(status);
+				assertThat(apiResponse.getBody().getData()).isEqualTo(message);
+				assertThat(apiResponse.getBody().getStatus()).isEqualTo(status.value());
+			}
+
+			@Test
+			@DisplayName("data가 객체인 경우도 APIResponse를 생성할 수 있다.")
+			void APIResponseWithObjectData() throws JsonProcessingException {
+				//given
+				HttpStatus status = HttpStatus.OK;
+				Example example = new Example(27, "Hyeon-Uk");
+
+				//when
+				ResponseEntity<APIResponse<Example>> apiResponse = APIUtils.of(status, example);
+
+				//then
+				assertThat(apiResponse.getStatusCode()).isEqualTo(status);
+				assertThat(apiResponse.getBody().getData()).isEqualTo(example);
+				assertThat(apiResponse.getBody().getStatus()).isEqualTo(status.value());
+			}
+
+			private class Example {
+				int age;
+				String name;
+
+				public Example(int age, String name) {
+					this.age = age;
+					this.name = name;
+				}
+
+				public int getAge() {
+					return age;
+				}
+
+				public String getName() {
+					return name;
+				}
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #22 
### Discussion Link - #13 

-  HTTP Status 값과 Response Type을 받는 생성자를 통해 통일된 API Response 를 얻을 수 있다.

<br>

## 💡 이런 고민을 했어요.

- APIResponse 객체를 APIUtils 클래스의 of메서드로만 생성할 수 있도록 APIResponse의 생성자를 default 접근 제어자로 설정했습니다.
```java
public class APIResponse<T> {
	private final T data;
	private final int status;

	APIResponse(final HttpStatus status, final T data) {
		this.data = data;
		this.status = status.value();
	}

	public T getData() {
		return data;
	}

	public int getStatus() {
		return status;
	}
}
```

<br>

## 기타
사용법은 아래와 같습니다.
```java
import org.springframework.http.HttpStatus;
import org.springframework.http.ResponseEntity;
import org.springframework.web.bind.annotation.PostMapping;
import org.springframework.web.bind.annotation.RestController;

import camp.woowak.lab.web.api.utils.APIResponse;
import camp.woowak.lab.web.api.utils.APIUtils;
import lombok.AllArgsConstructor;
import lombok.Getter;

@RestController
public class ExampleController {
	@PostMapping
	public ResponseEntity<APIResponse<Example>> example() {
		Example example = new Example(27, "Hyeon-Uk");

		return APIUtils.of(HttpStatus.OK, example);
	}

	@Getter
	@AllArgsConstructor
	private class Example {
		private int age;
		private String name;
	}
}
```

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] wiki를 수정했습니다.
