### PR TITLE
인증 인가

### DIFF
--- a/src/main/java/camp/woowak/lab/common/exception/ErrorCode.java
+++ b/src/main/java/camp/woowak/lab/common/exception/ErrorCode.java
@@ -2,6 +2,8 @@ package camp.woowak.lab.common.exception;
 
 public interface ErrorCode {
 	int getStatus();
+
 	String getErrorCode();
+
 	String getMessage();
 }

--- a/src/main/java/camp/woowak/lab/common/exception/UnauthorizedRequestException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/UnauthorizedRequestException.java
@@ -1,0 +1,6 @@
+package camp.woowak.lab.common.exception;
+
+public class UnauthorizedRequestException extends RuntimeException {
+	public UnauthorizedRequestException(String message) {
+	}
+}

--- a/src/main/java/camp/woowak/lab/common/exception/UnauthorizedRequestException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/UnauthorizedRequestException.java
@@ -1,6 +1,0 @@
-package camp.woowak.lab.common.exception;
-
-public class UnauthorizedRequestException extends RuntimeException {
-	public UnauthorizedRequestException(String message) {
-	}
-}

--- a/src/main/java/camp/woowak/lab/web/authentication/AuthenticationErrorCode.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/AuthenticationErrorCode.java
@@ -1,0 +1,34 @@
+package camp.woowak.lab.web.authentication;
+
+import org.springframework.http.HttpStatus;
+
+import camp.woowak.lab.common.exception.ErrorCode;
+
+public enum AuthenticationErrorCode implements ErrorCode {
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "a1", "로그인이 필요합니다.");
+
+	private final int status;
+	private final String errorCode;
+	private final String message;
+
+	AuthenticationErrorCode(HttpStatus httpStatus, String errorCode, String message) {
+		this.status = httpStatus.value();
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginCustomer.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginCustomer.java
@@ -1,0 +1,14 @@
+package camp.woowak.lab.web.authentication;
+
+public class LoginCustomer implements LoginMember {
+	private final Long id;
+
+	public LoginCustomer(Long id) {
+		this.id = id;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
@@ -1,0 +1,5 @@
+package camp.woowak.lab.web.authentication;
+
+public interface LoginMember {
+	Long getId();
+}

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginVendor.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginVendor.java
@@ -1,0 +1,14 @@
+package camp.woowak.lab.web.authentication;
+
+public class LoginVendor implements LoginMember {
+	private final Long id;
+
+	public LoginVendor(Long id) {
+		this.id = id;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/authentication/annotation/AuthenticationPrincipal.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/annotation/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package camp.woowak.lab.web.authentication.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+	boolean required() default true;
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/LoginMemberArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/LoginMemberArgumentResolver.java
@@ -1,0 +1,15 @@
+package camp.woowak.lab.web.resolver.session;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import camp.woowak.lab.web.authentication.LoginMember;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+
+public abstract class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthenticationPrincipal.class)
+			&& LoginMember.class.isAssignableFrom(parameter.getParameterType());
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionConst.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionConst.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.web.resolver.session;
+
+public final class SessionConst {
+	public static final String SESSION_VENDOR_KEY = "authentication_vendor";
+	public static final String SESSION_CUSTOMER_KEY = "authentication_customer";
+
+	private SessionConst() {
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolver.java
@@ -1,0 +1,36 @@
+package camp.woowak.lab.web.resolver.session;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+public class SessionCustomerArgumentResolver extends LoginMemberArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthenticationPrincipal.class)
+			&& LoginCustomer.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		AuthenticationPrincipal parameterAnnotation = parameter.getParameterAnnotation(AuthenticationPrincipal.class);
+		if (parameterAnnotation == null) {
+			return null;
+		}
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpSession session = request.getSession(false);
+		if (parameterAnnotation.required() &&
+			(session == null || session.getAttribute(SessionConst.SESSION_CUSTOMER_KEY) == null)) {
+			throw new UnauthorizedRequestException("Required session is null");
+		}
+		return session == null ? null : session.getAttribute(SessionConst.SESSION_CUSTOMER_KEY);
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolver.java
@@ -5,7 +5,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.common.exception.UnauthorizedException;
+import camp.woowak.lab.web.authentication.AuthenticationErrorCode;
 import camp.woowak.lab.web.authentication.LoginCustomer;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +30,7 @@ public class SessionCustomerArgumentResolver extends LoginMemberArgumentResolver
 		HttpSession session = request.getSession(false);
 		if (parameterAnnotation.required() &&
 			(session == null || session.getAttribute(SessionConst.SESSION_CUSTOMER_KEY) == null)) {
-			throw new UnauthorizedRequestException("Required session is null");
+			throw new UnauthorizedException(AuthenticationErrorCode.UNAUTHORIZED);
 		}
 		return session == null ? null : session.getAttribute(SessionConst.SESSION_CUSTOMER_KEY);
 	}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
@@ -1,0 +1,36 @@
+package camp.woowak.lab.web.resolver.session;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.web.authentication.LoginVendor;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+public class SessionVendorArgumentResolver extends LoginMemberArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthenticationPrincipal.class)
+			&& LoginVendor.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		AuthenticationPrincipal parameterAnnotation = parameter.getParameterAnnotation(AuthenticationPrincipal.class);
+		if (parameterAnnotation == null) {
+			return null;
+		}
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpSession session = request.getSession(false);
+		if (parameterAnnotation.required() &&
+			(session == null || session.getAttribute(SessionConst.SESSION_VENDOR_KEY) == null)) {
+			throw new UnauthorizedRequestException("Required session is null");
+		}
+		return session == null ? null : session.getAttribute(SessionConst.SESSION_VENDOR_KEY);
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
@@ -5,7 +5,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.common.exception.UnauthorizedException;
+import camp.woowak.lab.web.authentication.AuthenticationErrorCode;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +30,7 @@ public class SessionVendorArgumentResolver extends LoginMemberArgumentResolver {
 		HttpSession session = request.getSession(false);
 		if (parameterAnnotation.required() &&
 			(session == null || session.getAttribute(SessionConst.SESSION_VENDOR_KEY) == null)) {
-			throw new UnauthorizedRequestException("Required session is null");
+			throw new UnauthorizedException(AuthenticationErrorCode.UNAUTHORIZED);
 		}
 		return session == null ? null : session.getAttribute(SessionConst.SESSION_VENDOR_KEY);
 	}

--- a/src/test/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolverTest.java
+++ b/src/test/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolverTest.java
@@ -1,0 +1,135 @@
+package camp.woowak.lab.web.resolver.session;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.LoginVendor;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+@ExtendWith(MockitoExtension.class)
+public class SessionCustomerArgumentResolverTest {
+	@InjectMocks
+	private SessionCustomerArgumentResolver resolver;
+	@Mock
+	private MethodParameter methodParameter;
+	@Mock
+	private NativeWebRequest webRequest;
+	@Mock
+	private HttpServletRequest request;
+	@Mock
+	private HttpSession session;
+	@Mock
+	private LoginCustomer mockCustomer;
+
+	@Nested
+	@DisplayName("supportsParameter")
+	class SupportsParameter {
+		@Test
+		@DisplayName("[True] 파라미터에 @AuthenticationPrincipal이 붙은 경우")
+		public void supportsParameter_ReturnsTrue_WhenCorrectAnnotationAndType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(true);
+			when(methodParameter.getParameterType()).thenReturn((Class)LoginCustomer.class);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isTrue();
+		}
+
+		@Test
+		@DisplayName("[False] 파라미터가 LoginCustomer가 아닌 경우")
+		public void supportsParameter_ReturnsTrue_WhenIncorrectType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(true);
+			when(methodParameter.getParameterType()).thenReturn((Class)LoginVendor.class);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isFalse();
+		}
+
+		@Test
+		@DisplayName("[False] 파라미터에 @AuthenticationPrincipal이 붙지 않은 경우")
+		public void supportsParameter_ReturnsFalse_WhenIncorrectAnnotationOrType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(false);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isFalse();
+		}
+	}
+
+	@Nested
+	@DisplayName("resolveArgument")
+	class ResolveArgument {
+		@Test
+		@DisplayName("[LoginCustomer] 세션에 LoginCustomer가 있는 경우")
+		public void resolveArgument_ReturnsCustomer_WhenSessionExists() throws Exception {
+			when(webRequest.getNativeRequest()).thenReturn(request);
+			when(request.getSession(false)).thenReturn(session);
+			when(session.getAttribute(SessionConst.SESSION_CUSTOMER_KEY)).thenReturn(mockCustomer);
+			when(methodParameter.getParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(
+				new AuthenticationPrincipal() {
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return null;
+					}
+
+					@Override
+					public boolean required() {
+						return true;
+					}
+				}
+			);
+
+			Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+			assertThat(result).isEqualTo(mockCustomer);
+		}
+
+		@Test
+		@DisplayName("[Null] 파라미터에 @AuthenticationPrincipal이 붙지 않은 경우")
+		public void resolveArgument_ReturnsNull_WhenSessionDoesNotExist() throws Exception {
+			Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+			assertThat(result).isNull();
+		}
+
+		@Test
+		@DisplayName("[UnauthorizedRequestException] @AuthenticationPrincipal(required=true)인데 세션이 LoginCustomer가 없는 경우")
+		public void resolveArgument_ThrowsException_WhenSessionRequiredButMissing() {
+			when(webRequest.getNativeRequest()).thenReturn(request);
+			when(methodParameter.getParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(
+				new AuthenticationPrincipal() {
+					@Override
+					public boolean required() {
+						return true;
+					}
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return AuthenticationPrincipal.class;
+					}
+				});
+
+			assertThrows(
+				UnauthorizedRequestException.class,
+				() -> resolver.resolveArgument(methodParameter, null, webRequest, null));
+		}
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolverTest.java
+++ b/src/test/java/camp/woowak/lab/web/resolver/session/SessionCustomerArgumentResolverTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.common.exception.UnauthorizedException;
 import camp.woowak.lab.web.authentication.LoginCustomer;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
@@ -128,7 +128,7 @@ public class SessionCustomerArgumentResolverTest {
 				});
 
 			assertThrows(
-				UnauthorizedRequestException.class,
+				UnauthorizedException.class,
 				() -> resolver.resolveArgument(methodParameter, null, webRequest, null));
 		}
 	}

--- a/src/test/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolverTest.java
+++ b/src/test/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolverTest.java
@@ -1,0 +1,135 @@
+package camp.woowak.lab.web.resolver.session;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.LoginVendor;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+@ExtendWith(MockitoExtension.class)
+class SessionVendorArgumentResolverTest {
+	@InjectMocks
+	private SessionVendorArgumentResolver resolver;
+	@Mock
+	private MethodParameter methodParameter;
+	@Mock
+	private NativeWebRequest webRequest;
+	@Mock
+	private HttpServletRequest request;
+	@Mock
+	private HttpSession session;
+	@Mock
+	private LoginVendor mockVendor;
+
+	@Nested
+	@DisplayName("supportsParameter")
+	class SupportsParameter {
+		@Test
+		@DisplayName("[True] 파라미터에 @AuthenticationPrincipal이 붙은 경우")
+		public void supportsParameter_ReturnsTrue_WhenCorrectAnnotationAndType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(true);
+			when(methodParameter.getParameterType()).thenReturn((Class)LoginVendor.class);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isTrue();
+		}
+
+		@Test
+		@DisplayName("[False] 파라미터가 LoginVendor가 아닌 경우")
+		public void supportsParameter_ReturnsTrue_WhenIncorrectType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(true);
+			when(methodParameter.getParameterType()).thenReturn((Class)LoginCustomer.class);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isFalse();
+		}
+
+		@Test
+		@DisplayName("[False] 파라미터에 @AuthenticationPrincipal이 붙지 않은 경우")
+		public void supportsParameter_ReturnsFalse_WhenIncorrectAnnotationOrType() {
+			when(methodParameter.hasParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(false);
+
+			boolean supports = resolver.supportsParameter(methodParameter);
+
+			assertThat(supports).isFalse();
+		}
+	}
+
+	@Nested
+	@DisplayName("resolveArgument")
+	class ResolveArgument {
+		@Test
+		@DisplayName("[LoginVendor] 세션에 LoginVendor 있는 경우")
+		public void resolveArgument_ReturnsVendor_WhenSessionExists() throws Exception {
+			when(webRequest.getNativeRequest()).thenReturn(request);
+			when(request.getSession(false)).thenReturn(session);
+			when(session.getAttribute(SessionConst.SESSION_VENDOR_KEY)).thenReturn(mockVendor);
+			when(methodParameter.getParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(
+				new AuthenticationPrincipal() {
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return null;
+					}
+
+					@Override
+					public boolean required() {
+						return true;
+					}
+				}
+			);
+
+			Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+			assertThat(result).isEqualTo(mockVendor);
+		}
+
+		@Test
+		@DisplayName("[Null] 파라미터에 @AuthenticationPrincipal이 붙지 않은 경우")
+		public void resolveArgument_ReturnsNull_WhenSessionDoesNotExist() throws Exception {
+			Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+			assertThat(result).isNull();
+		}
+
+		@Test
+		@DisplayName("[UnauthorizedRequestException] @AuthenticationPrincipal(required=true)인데 세션이 LoginVendor가 없는 경우")
+		public void resolveArgument_ThrowsException_WhenSessionRequiredButMissing() {
+			when(webRequest.getNativeRequest()).thenReturn(request);
+			when(methodParameter.getParameterAnnotation(AuthenticationPrincipal.class)).thenReturn(
+				new AuthenticationPrincipal() {
+					@Override
+					public boolean required() {
+						return true;
+					}
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return AuthenticationPrincipal.class;
+					}
+				});
+
+			assertThrows(
+				UnauthorizedRequestException.class,
+				() -> resolver.resolveArgument(methodParameter, null, webRequest, null));
+		}
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolverTest.java
+++ b/src/test/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolverTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import camp.woowak.lab.common.exception.UnauthorizedRequestException;
+import camp.woowak.lab.common.exception.UnauthorizedException;
 import camp.woowak.lab.web.authentication.LoginCustomer;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
@@ -128,7 +128,7 @@ class SessionVendorArgumentResolverTest {
 				});
 
 			assertThrows(
-				UnauthorizedRequestException.class,
+				UnauthorizedException.class,
 				() -> resolver.resolveArgument(methodParameter, null, webRequest, null));
 		}
 	}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #21 

- 인증 : Controller에서 `@AuthenticationPrincipal`과 `LoginCustomer`(또는 `LoginVendor`)의 조합으로 세션이 유지중인 사용자 정보를 조회할 수 있습니다.
- 인가 : `@AuthenticationPrincipal`의 required 값이 true임에도 불구하고 사용자 정보가 조회되지 않으면 `UnauthenticationException`이 발생합니다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- ArgumentResovler(Vendor / Customer)
- LoginVendor / LoginCustomer

<br>

## 💡 이런 고민을 했어요.

- Vendor와 Customer를 통합한 인증 객체를 만들까?
   - Vendor 및 Customer에 대한 인가 정책이 분리되어 있으므로 (즉, Vendor용 api, Customer용 api가 분리되어 있으므로) 인증 객체를 따로 두어야합니다.
- Spring Security 의존성 추가될 때 최대한 영향이 적게 만들 수 있을까?
   - CustomArgumentResolver를 구현하고, 추후 `AuthenticationPrincipalArgumentResolver` (Spring Security에서 제공하는 ArgumentResolver)의 내부 로직을 그대로 사용하면 되겠다.

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
