### PR TITLE
GlobalExceptionHandler 응답 방식 수정

### DIFF
--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package camp.woowak.lab.common.advice;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,12 +12,11 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ProblemDetail> handleAllUncaughtException(Exception e) {
+	public ProblemDetail handleAllUncaughtException(Exception e) {
 		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
 			e.getMessage());
 		problemDetail.setProperty("errorCode", "9999");
 
-		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-			.body(problemDetail);
+		return problemDetail;
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -17,6 +17,8 @@ public class GlobalExceptionHandler {
 			e.getMessage());
 		problemDetail.setProperty("errorCode", "9999");
 
+		log.error("[Unexpected Exception]", e);
+
 		return problemDetail;
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ public class GlobalExceptionHandler {
 		problemDetail.setProperty("errorCode", "9999");
 
 		log.error("[Unexpected Exception]", e);
+		// TODO: Notion Hook 등록
 
 		return problemDetail;
 	}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #33 
### Discussion Link - #31 
- 논의 - #31 에 따라 ResponseEntity 가 아닌 ProblemDetail 를 넘기도록 수정

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- GlobalExceptionHandler:
  - ResponseEntity 가 아닌 ProblemDetail 로 전달하도록 변경
  - 추후 수정에 대한 TODO 작성
  - 예외 로깅 추가
<br>

## 💡 이런 고민을 했어요.

- 예외 로깅을 어떻게 하면 좋을까요?
  - `log.error("[{exception type}]", e);`

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
