### PR TITLE
[feat] 컨트롤러 API 공통 응답 처리

### DIFF
--- a/src/main/java/camp/woowak/lab/web/advice/APIResponseAdvice.java
+++ b/src/main/java/camp/woowak/lab/web/advice/APIResponseAdvice.java
@@ -1,0 +1,39 @@
+package camp.woowak.lab.web.advice;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RestControllerAdvice
+@Slf4j
+public class APIResponseAdvice implements ResponseBodyAdvice<Object> {
+
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return converterType.isAssignableFrom(MappingJackson2HttpMessageConverter.class)
+			&& !returnType.getParameterType().equals(ResponseEntity.class)
+			&& !returnType.getParameterType().equals(ProblemDetail.class);
+	}
+
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+								  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+								  ServerHttpRequest request, ServerHttpResponse response
+	) {
+		// TODO
+
+		return null;
+	}
+
+}

--- a/src/main/java/camp/woowak/lab/web/advice/APIResponseAdvice.java
+++ b/src/main/java/camp/woowak/lab/web/advice/APIResponseAdvice.java
@@ -1,6 +1,7 @@
 package camp.woowak.lab.web.advice;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -8,10 +9,13 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
+import camp.woowak.lab.web.api.utils.APIResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
@@ -31,9 +35,27 @@ public class APIResponseAdvice implements ResponseBodyAdvice<Object> {
 								  Class<? extends HttpMessageConverter<?>> selectedConverterType,
 								  ServerHttpRequest request, ServerHttpResponse response
 	) {
-		// TODO
+		HttpStatus status = getHttpStatus(returnType, (ServletServerHttpResponse)response);
+		if (body == null) {
+			return new APIResponse<>(status, "No content");
+		}
 
-		return null;
+		if (body instanceof APIResponse) {
+			return body;
+		}
+
+		return new APIResponse<>(status, body);
 	}
 
+	private HttpStatus getHttpStatus(MethodParameter returnType, ServletServerHttpResponse response) {
+		HttpStatus status;
+		if (returnType.hasMethodAnnotation(ResponseStatus.class)) {
+			ResponseStatus responseStatus = returnType.getMethodAnnotation(ResponseStatus.class);
+			if (responseStatus != null) {
+				return responseStatus.value();
+			}
+		}
+		status = HttpStatus.valueOf(response.getServletResponse().getStatus());
+		return status;
+	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/customer/CustomerApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/customer/CustomerApiController.java
@@ -1,15 +1,13 @@
 package camp.woowak.lab.web.api.customer;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import camp.woowak.lab.customer.service.SignUpCustomerService;
 import camp.woowak.lab.customer.service.command.SignUpCustomerCommand;
-import camp.woowak.lab.web.api.utils.APIResponse;
-import camp.woowak.lab.web.api.utils.APIUtils;
 import camp.woowak.lab.web.dto.request.customer.SignUpCustomerRequest;
 import camp.woowak.lab.web.dto.response.customer.SignUpCustomerResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,8 +22,9 @@ public class CustomerApiController {
 	}
 
 	@PostMapping("/customers")
-	public ResponseEntity<APIResponse<SignUpCustomerResponse>> signUp(@Valid @RequestBody SignUpCustomerRequest request,
-																	  HttpServletResponse response) {
+	@ResponseStatus(HttpStatus.CREATED)
+	public SignUpCustomerResponse signUp(@Valid @RequestBody SignUpCustomerRequest request,
+										 HttpServletResponse response) {
 		SignUpCustomerCommand command =
 			new SignUpCustomerCommand(request.name(), request.email(), request.password(), request.phone());
 
@@ -33,6 +32,6 @@ public class CustomerApiController {
 
 		response.setHeader("Location", "/customers/" + registeredId);
 
-		return APIUtils.of(HttpStatus.CREATED, new SignUpCustomerResponse(registeredId));
+		return new SignUpCustomerResponse(registeredId);
 	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/payaccount/PayAccountApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/payaccount/PayAccountApiController.java
@@ -1,17 +1,15 @@
 package camp.woowak.lab.web.api.payaccount;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import camp.woowak.lab.payaccount.service.PayAccountChargeService;
 import camp.woowak.lab.payaccount.service.command.PayAccountChargeCommand;
-import camp.woowak.lab.web.api.utils.APIResponse;
-import camp.woowak.lab.web.api.utils.APIUtils;
 import camp.woowak.lab.web.authentication.LoginCustomer;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
 import camp.woowak.lab.web.dto.request.payaccount.PayAccountChargeRequest;
@@ -32,9 +30,10 @@ public class PayAccountApiController {
 	 * TODO 1. api end-point 설계 논의
 	 */
 	@PostMapping("/charge")
-	public ResponseEntity<APIResponse<PayAccountChargeResponse>> payAccountCharge(
-		@AuthenticationPrincipal LoginCustomer loginCustomer,
-		@Validated @RequestBody PayAccountChargeRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	public PayAccountChargeResponse payAccountCharge(@AuthenticationPrincipal LoginCustomer loginCustomer,
+													 @Validated @RequestBody PayAccountChargeRequest request
+	) {
 		PayAccountChargeCommand command = new PayAccountChargeCommand(loginCustomer.getId(), request.amount());
 		log.info("Pay account charge request received. Account Owner ID: {}, Charge Amount: {}", loginCustomer.getId(),
 			request.amount());
@@ -42,6 +41,6 @@ public class PayAccountApiController {
 		long remainBalance = payAccountChargeService.chargeAccount(command);
 		log.info("Charge successful. Account Owner ID: {}, New Balance: {}", loginCustomer.getId(), remainBalance);
 
-		return APIUtils.of(HttpStatus.OK, new PayAccountChargeResponse(remainBalance));
+		return new PayAccountChargeResponse(remainBalance);
 	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
@@ -21,10 +21,7 @@ public class StoreApiController {
 	private final StoreRegistrationService storeRegistrationService;
 	private final VendorRepository vendorRepository;
 
-	// TODO:
-	//  1. 인증/인가에 대한 스펙이 정의되어야, Vendor Resolver 로직을 결정할 수 있음
-	//  2. SSR, CSR 에 대해 통일해야, API 반환타입을 fix 할 수 있음
-	//  3. API 공통 응답 명세에 대한 논의 진행 필요
+	// TODO: 서비스 메서드 코드 스타일 통일하면서 dtoResponse 반환하도록 수정할 예정
 	@PostMapping("/stores")
 	public ResponseEntity<Void> storeRegistration(@AuthenticationPrincipal final LoginVendor loginVendor,
 												  final @Valid @RequestBody StoreRegistrationRequest request

--- a/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
+++ b/src/main/java/camp/woowak/lab/web/api/utils/APIResponse.java
@@ -10,7 +10,7 @@ public class APIResponse<T> {
 	private final T data;
 	private final int status;
 
-	APIResponse(final HttpStatus status, final T data) {
+	public APIResponse(final HttpStatus status, final T data) {
 		this.data = data;
 		this.status = status.value();
 	}

--- a/src/main/java/camp/woowak/lab/web/api/utils/APIUtils.java
+++ b/src/main/java/camp/woowak/lab/web/api/utils/APIUtils.java
@@ -9,10 +9,12 @@ import org.springframework.http.ResponseEntity;
  * of Method는 status와 data를 이용해 APIResponse객체를 만들 수 있습니다.
  *
  */
+@Deprecated(since = "APIResponseAdvice 에서 APIResponse 를 반환하는 구조여서, 현재는 ResponseEntity 를 사용하지 않습니다.")
 public final class APIUtils {
 	private APIUtils() {
 	}
 
+	@Deprecated
 	public static <T> ResponseEntity<APIResponse<T>> of(HttpStatus status, T data) {
 		return new ResponseEntity<>(new APIResponse<>(status, data), status);
 	}

--- a/src/main/java/camp/woowak/lab/web/api/vendor/VendorApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/vendor/VendorApiController.java
@@ -1,7 +1,6 @@
 package camp.woowak.lab.web.api.vendor;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -9,8 +8,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import camp.woowak.lab.vendor.service.SignUpVendorService;
 import camp.woowak.lab.vendor.service.command.SignUpVendorCommand;
-import camp.woowak.lab.web.api.utils.APIResponse;
-import camp.woowak.lab.web.api.utils.APIUtils;
 import camp.woowak.lab.web.dto.request.vendor.SignUpVendorRequest;
 import camp.woowak.lab.web.dto.response.vendor.SignUpVendorResponse;
 import jakarta.validation.Valid;
@@ -25,11 +22,11 @@ public class VendorApiController {
 
 	@PostMapping("/vendors")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<APIResponse<SignUpVendorResponse>> signUpVendor(
-		@Valid @RequestBody SignUpVendorRequest request) {
+	public SignUpVendorResponse signUpVendor(@Valid @RequestBody SignUpVendorRequest request) {
+
 		SignUpVendorCommand command =
 			new SignUpVendorCommand(request.name(), request.email(), request.password(), request.phone());
 		Long registeredId = signUpVendorService.signUp(command);
-		return APIUtils.of(HttpStatus.CREATED, new SignUpVendorResponse(registeredId));
+		return new SignUpVendorResponse(registeredId);
 	}
 }

--- a/src/test/java/camp/woowak/lab/web/advice/APIResponseAdviceTest.java
+++ b/src/test/java/camp/woowak/lab/web/advice/APIResponseAdviceTest.java
@@ -1,0 +1,89 @@
+package camp.woowak.lab.web.advice;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class APIResponseAdviceTest {
+
+	@InjectMocks
+	private APIResponseAdvice apiResponseAdvice;
+
+	@Mock
+	private MethodParameter methodParameter;
+
+	@Mock
+	private ServerHttpRequest request;
+
+	@Mock
+	private ServletServerHttpResponse response;
+
+	@Mock
+	private HttpServletResponse servletResponse;
+
+	@Nested
+	@DisplayName("supports 메서드는")
+	class Supports {
+
+		@Test
+		@DisplayName("MappingJackson2HttpMessageConverter 타입이고 ResponseEntity나 ProblemDetail이 아닐 때 true를 반환해야 한다")
+		void supports_ShouldReturnTrue_WhenConverterTypeIsAssignable() {
+			// Given
+			Class<? extends HttpMessageConverter<?>> converterType = MappingJackson2HttpMessageConverter.class;
+			given(methodParameter.getParameterType()).willReturn((Class)Object.class);
+
+			// When
+			boolean result = apiResponseAdvice.supports(methodParameter, converterType);
+
+			// Then
+			assertThat(result).isTrue();
+		}
+
+		@Test
+		@DisplayName("반환 타입이 ResponseEntity일 때 false를 반환해야 한다")
+		void supports_ShouldReturnFalse_WhenReturnTypeIsResponseEntity() {
+			// Given
+			Class<? extends HttpMessageConverter<?>> converterType = MappingJackson2HttpMessageConverter.class;
+			given(methodParameter.getParameterType()).willReturn((Class)ResponseEntity.class);
+
+			// When
+			boolean result = apiResponseAdvice.supports(methodParameter, converterType);
+
+			// Then
+			assertThat(result).isFalse();
+		}
+
+		@Test
+		@DisplayName("반환 타입이 ProblemDetail일 때 false를 반환해야 한다")
+		void supports_ShouldReturnFalse_WhenReturnTypeIsProblemDetails() {
+			// Given
+			Class<? extends HttpMessageConverter<?>> converterType = MappingJackson2HttpMessageConverter.class;
+			given(methodParameter.getParameterType()).willReturn((Class)ProblemDetail.class);
+
+			// When
+			boolean result = apiResponseAdvice.supports(methodParameter, converterType);
+
+			// Then
+			assertThat(result).isFalse();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #32
`APIResponseAdvice` 에서 컨트롤러의 responseDTO 를 APIResponse 로 응답하도록 공통 로직을 처리

- supports 메서드에서 해당 어드바이스가 처리해도 되는지 확인
  - api 이기 때문에, `MappingJackson2HttpMessageConverter` 컨버터가 아니면 무시
  - ResponseEntity 인 경우 무시
  - ProblemDetail 인 경우 무시

- beforeBodyWrite 에서 공통 로직을 수행
  - @HttpStatus 로 상태코드를 명시했다면, 해당 상태코드를 가져옴
  - response 에 상태코드를 명시했다면, 해당 상태코드를 가져옴
  - API 공통 응답 명세인 APIResponse 객체를 반환


🔔 notice:
- APIResponse의 생성자 접근제어자를 public으로 변경했습니다.
- APIResponseUtils의 경우 현재 사용되지 않는 상황입니다. 혹시 몰라서 코드는 남겨두었습니다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 기존 API 컨트롤러의 반환 타입 변경 및 @HttpStatus 명시
[[refactor] 구매자 회원가입 컨트롤러 반환타입 변경](https://github.com/woowa-techcamp-2024/Team1-3K1K/commit/611d1e1fb8fb94dc010cce8b417ee3c25ae5c502)
[[refactor] 계좌 충전 컨트롤러 반환타입 변경](https://github.com/woowa-techcamp-2024/Team1-3K1K/commit/b8d47166a05e1ba816b8f46975c4620d1a92c731)
[[refactor] 점주 회원가입 컨트롤러 반환타입 변경](https://github.com/woowa-techcamp-2024/Team1-3K1K/commit/3103f08541a4350d2970fd4768cd4af997c850d7)



<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] wiki를 수정했습니다.
