### PR TITLE
[refactor] Payaccount CustomException 수정

### DIFF
--- a/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
@@ -4,4 +4,8 @@ public class NotFoundException extends HttpStatusException {
 	public NotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}
+
+	public NotFoundException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/domain/PayAccount.java
+++ b/src/main/java/camp/woowak/lab/payaccount/domain/PayAccount.java
@@ -86,22 +86,19 @@ public class PayAccount {
 			.sum();
 
 		if (todayTotalCharge + amount > 1_000_000) {
-			log.warn("Daily charge limit of {} exceeded.", 1_000_000);
-			throw new DailyLimitExceededException();
+			throw new DailyLimitExceededException("Daily charge limit of " + 1_000_000 + " exceeded.");
 		}
 	}
 
 	private void validateTransactionAmount(long amount) {
 		if (amount <= 0) {
-			log.warn("Transaction amount must be greater than zero.");
-			throw new InvalidTransactionAmountException();
+			throw new InvalidTransactionAmountException("Transaction amount must be greater than zero.");
 		}
 	}
 
 	private void validateInsufficientBalance(long amount) {
 		if (this.balance - amount < 0) {
-			log.warn("Insufficient balance for this transaction.");
-			throw new InsufficientBalanceException();
+			throw new InsufficientBalanceException("Insufficient balance for this transaction.");
 		}
 	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/exception/DailyLimitExceededException.java
+++ b/src/main/java/camp/woowak/lab/payaccount/exception/DailyLimitExceededException.java
@@ -3,7 +3,7 @@ package camp.woowak.lab.payaccount.exception;
 import camp.woowak.lab.common.exception.BadRequestException;
 
 public class DailyLimitExceededException extends BadRequestException {
-	public DailyLimitExceededException() {
-		super(PayAccountErrorCode.DAILY_LIMIT_EXCEED);
+	public DailyLimitExceededException(String message) {
+		super(PayAccountErrorCode.DAILY_LIMIT_EXCEED, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/exception/InsufficientBalanceException.java
+++ b/src/main/java/camp/woowak/lab/payaccount/exception/InsufficientBalanceException.java
@@ -3,7 +3,7 @@ package camp.woowak.lab.payaccount.exception;
 import camp.woowak.lab.common.exception.BadRequestException;
 
 public class InsufficientBalanceException extends BadRequestException {
-	public InsufficientBalanceException() {
-		super(PayAccountErrorCode.INSUFFICIENT_BALANCE);
+	public InsufficientBalanceException(String message) {
+		super(PayAccountErrorCode.INSUFFICIENT_BALANCE, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/exception/InvalidTransactionAmountException.java
+++ b/src/main/java/camp/woowak/lab/payaccount/exception/InvalidTransactionAmountException.java
@@ -3,7 +3,7 @@ package camp.woowak.lab.payaccount.exception;
 import camp.woowak.lab.common.exception.BadRequestException;
 
 public class InvalidTransactionAmountException extends BadRequestException {
-	public InvalidTransactionAmountException() {
-		super(PayAccountErrorCode.INVALID_TRANSACTION_AMOUNT);
+	public InvalidTransactionAmountException(String message) {
+		super(PayAccountErrorCode.INVALID_TRANSACTION_AMOUNT, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/exception/NotFoundAccountException.java
+++ b/src/main/java/camp/woowak/lab/payaccount/exception/NotFoundAccountException.java
@@ -3,7 +3,7 @@ package camp.woowak.lab.payaccount.exception;
 import camp.woowak.lab.common.exception.NotFoundException;
 
 public class NotFoundAccountException extends NotFoundException {
-	public NotFoundAccountException() {
-		super(PayAccountErrorCode.ACCOUNT_NOT_FOUND);
+	public NotFoundAccountException(String message) {
+		super(PayAccountErrorCode.ACCOUNT_NOT_FOUND, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/payaccount/service/PayAccountChargeService.java
+++ b/src/main/java/camp/woowak/lab/payaccount/service/PayAccountChargeService.java
@@ -27,8 +27,7 @@ public class PayAccountChargeService {
 	public long chargeAccount(PayAccountChargeCommand command) {
 		PayAccount payAccount = payAccountRepository.findByCustomerIdForUpdate(command.customerId())
 			.orElseThrow(() -> {
-				log.warn("Invalid account id with {}", command.customerId());
-				throw new NotFoundAccountException();
+				throw new NotFoundAccountException("Invalid account id with " + command.customerId());
 			});
 
 		PayAccountHistory chargeHistory = payAccount.charge(command.amount());


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #56
PayAccount 도메인 및 서비스에서 발생할 수 있는 PayAccount CustomException에 서버 로깅용 메세지를 포함해서 던지도록 CustomException 수정

<br>
## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] wiki를 수정했습니다.
