### PR TITLE
[feat] Customer id 변경

### DIFF
--- a/src/main/java/camp/woowak/lab/customer/domain/Customer.java
+++ b/src/main/java/camp/woowak/lab/customer/domain/Customer.java
@@ -1,5 +1,7 @@
 package camp.woowak.lab.customer.domain;
 
+import java.util.UUID;
+
 import camp.woowak.lab.customer.exception.InvalidCreationException;
 import camp.woowak.lab.payaccount.domain.PayAccount;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
@@ -10,14 +12,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
 @Getter
+@Table(name = "Customers")
 public class Customer {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
 	@Column(nullable = false, length = 50)
 	private String name;
 	@Column(unique = true, nullable = false, length = 100)

--- a/src/main/java/camp/woowak/lab/customer/service/SignUpCustomerService.java
+++ b/src/main/java/camp/woowak/lab/customer/service/SignUpCustomerService.java
@@ -12,7 +12,9 @@ import camp.woowak.lab.payaccount.domain.PayAccount;
 import camp.woowak.lab.payaccount.repository.PayAccountRepository;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class SignUpCustomerService {
 	private final CustomerRepository customerRepository;
@@ -20,7 +22,7 @@ public class SignUpCustomerService {
 	private final PasswordEncoder passwordEncoder;
 
 	public SignUpCustomerService(CustomerRepository customerRepository, PayAccountRepository payAccountRepository,
-								 PasswordEncoder passwordEncoder) {
+		PasswordEncoder passwordEncoder) {
 		this.customerRepository = customerRepository;
 		this.payAccountRepository = payAccountRepository;
 		this.passwordEncoder = passwordEncoder;
@@ -31,8 +33,8 @@ public class SignUpCustomerService {
 	 * @throws InvalidCreationException 구매자 생성에 오류가 나는 경우
 	 * @throws DuplicateEmailException 이메일이 중복되는 경우
 	 */
-	@Transactional
-	public Long signUp(SignUpCustomerCommand cmd) {
+	@Transactional()
+	public String signUp(SignUpCustomerCommand cmd) {
 		PayAccount payAccount = new PayAccount();
 		payAccountRepository.save(payAccount);
 
@@ -40,10 +42,10 @@ public class SignUpCustomerService {
 			passwordEncoder);
 
 		try {
-			customerRepository.save(newCustomer);
+			return customerRepository.saveAndFlush(newCustomer).getId().toString();
 		} catch (DataIntegrityViolationException e) {
+			log.error("데이터 무결성 위반");
 			throw new DuplicateEmailException();
 		}
-		return newCustomer.getId();
 	}
 }

--- a/src/main/java/camp/woowak/lab/customer/service/SignUpCustomerService.java
+++ b/src/main/java/camp/woowak/lab/customer/service/SignUpCustomerService.java
@@ -22,7 +22,7 @@ public class SignUpCustomerService {
 	private final PasswordEncoder passwordEncoder;
 
 	public SignUpCustomerService(CustomerRepository customerRepository, PayAccountRepository payAccountRepository,
-		PasswordEncoder passwordEncoder) {
+								 PasswordEncoder passwordEncoder) {
 		this.customerRepository = customerRepository;
 		this.payAccountRepository = payAccountRepository;
 		this.passwordEncoder = passwordEncoder;
@@ -33,7 +33,7 @@ public class SignUpCustomerService {
 	 * @throws InvalidCreationException 구매자 생성에 오류가 나는 경우
 	 * @throws DuplicateEmailException 이메일이 중복되는 경우
 	 */
-	@Transactional()
+	@Transactional
 	public String signUp(SignUpCustomerCommand cmd) {
 		PayAccount payAccount = new PayAccount();
 		payAccountRepository.save(payAccount);

--- a/src/main/java/camp/woowak/lab/payaccount/repository/PayAccountRepository.java
+++ b/src/main/java/camp/woowak/lab/payaccount/repository/PayAccountRepository.java
@@ -1,6 +1,7 @@
 package camp.woowak.lab.payaccount.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -13,5 +14,5 @@ import jakarta.persistence.LockModeType;
 public interface PayAccountRepository extends JpaRepository<PayAccount, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT pa FROM PayAccount pa LEFT JOIN Customer c on c.payAccount = pa where c.id = :customerId")
-	Optional<PayAccount> findByCustomerIdForUpdate(@Param("customerId") Long customerId);
+	Optional<PayAccount> findByCustomerIdForUpdate(@Param("customerId") UUID customerId);
 }

--- a/src/main/java/camp/woowak/lab/payaccount/service/command/PayAccountChargeCommand.java
+++ b/src/main/java/camp/woowak/lab/payaccount/service/command/PayAccountChargeCommand.java
@@ -1,6 +1,8 @@
 package camp.woowak.lab.payaccount.service.command;
 
+import java.util.UUID;
+
 public record PayAccountChargeCommand(
-	Long customerId,
+	UUID customerId,
 	long amount) {
 }

--- a/src/main/java/camp/woowak/lab/web/api/customer/CustomerApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/customer/CustomerApiController.java
@@ -28,7 +28,7 @@ public class CustomerApiController {
 		SignUpCustomerCommand command =
 			new SignUpCustomerCommand(request.name(), request.email(), request.password(), request.phone());
 
-		Long registeredId = signUpCustomerService.signUp(command);
+		String registeredId = signUpCustomerService.signUp(command);
 
 		response.setHeader("Location", "/customers/" + registeredId);
 

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginCustomer.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginCustomer.java
@@ -1,14 +1,16 @@
 package camp.woowak.lab.web.authentication;
 
-public class LoginCustomer implements LoginMember {
-	private final Long id;
+import java.util.UUID;
 
-	public LoginCustomer(Long id) {
+public class LoginCustomer implements LoginMember {
+	private final UUID id;
+
+	public LoginCustomer(UUID id) {
 		this.id = id;
 	}
 
 	@Override
-	public Long getId() {
+	public UUID getId() {
 		return id;
 	}
 }

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
@@ -1,7 +1,5 @@
 package camp.woowak.lab.web.authentication;
 
-import java.util.UUID;
-
 public interface LoginMember {
-	UUID getId();
+	Object getId();
 }

--- a/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
+++ b/src/main/java/camp/woowak/lab/web/authentication/LoginMember.java
@@ -1,5 +1,7 @@
 package camp.woowak.lab.web.authentication;
 
+import java.util.UUID;
+
 public interface LoginMember {
-	Object getId();
+	UUID getId();
 }

--- a/src/main/java/camp/woowak/lab/web/dto/response/customer/SignUpCustomerResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/customer/SignUpCustomerResponse.java
@@ -1,4 +1,4 @@
 package camp.woowak.lab.web.dto.response.customer;
 
-public record SignUpCustomerResponse(Long id) {
+public record SignUpCustomerResponse(String id) {
 }

--- a/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceIntegrationTest.java
+++ b/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import camp.woowak.lab.customer.exception.DuplicateEmailException;
 import camp.woowak.lab.customer.exception.InvalidCreationException;
@@ -43,10 +44,11 @@ class SignUpCustomerServiceIntegrationTest {
 		// then
 		try {
 			service.signUp(command2);
-			fail("중복 이메일 예외가 발생해야 합니다.");
 		} catch (DuplicateEmailException e) {
 			assertEquals(1, customerRepository.count());
 			assertEquals(1, payAccountRepository.count());
+		} catch (DataIntegrityViolationException e) {
+			fail("DataIntegrityViolationException이 발생했습니다.");
 		}
 	}
 }

--- a/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceIntegrationTest.java
+++ b/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceIntegrationTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import camp.woowak.lab.customer.exception.DuplicateEmailException;
-import camp.woowak.lab.customer.exception.InvalidCreationException;
 import camp.woowak.lab.customer.repository.CustomerRepository;
 import camp.woowak.lab.customer.service.command.SignUpCustomerCommand;
 import camp.woowak.lab.payaccount.repository.PayAccountRepository;
@@ -28,7 +27,7 @@ class SignUpCustomerServiceIntegrationTest {
 
 	@Test
 	@DisplayName("이메일 중복 시 롤백 테스트")
-	void testRollbackOnDuplicateEmail() throws InvalidCreationException, DuplicateEmailException {
+	void testRollbackOnDuplicateEmail() {
 		// given
 		SignUpCustomerCommand command1 = new SignUpCustomerCommand("name1", "email@example.com", "password",
 			"010-1234-5678");

--- a/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
+++ b/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.customer.exception.DuplicateEmailException;
-import camp.woowak.lab.customer.exception.InvalidCreationException;
 import camp.woowak.lab.customer.repository.CustomerRepository;
 import camp.woowak.lab.customer.service.command.SignUpCustomerCommand;
 import camp.woowak.lab.fixture.CustomerFixture;
@@ -47,7 +46,7 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 		PayAccount payAccount = createPayAccount();
 		Customer customerMock = Mockito.mock(Customer.class);
 		given(payAccountRepository.save(Mockito.any(PayAccount.class))).willReturn(payAccount);
-		given(customerRepository.save(Mockito.any(Customer.class))).willReturn(customerMock);
+		given(customerRepository.saveAndFlush(Mockito.any(Customer.class))).willReturn(customerMock);
 		when(customerMock.getId()).thenReturn(UUID.randomUUID());
 
 		// when
@@ -57,7 +56,7 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 
 		// then
 		then(payAccountRepository).should().save(Mockito.any(PayAccount.class));
-		then(customerRepository).should().save(Mockito.any(Customer.class));
+		then(customerRepository).should().saveAndFlush(Mockito.any(Customer.class));
 	}
 
 	@Test
@@ -66,7 +65,8 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 		// given
 		given(passwordEncoder.encode(Mockito.anyString())).willReturn("password");
 		given(payAccountRepository.save(Mockito.any(PayAccount.class))).willReturn(createPayAccount());
-		when(customerRepository.save(Mockito.any(Customer.class))).thenThrow(DataIntegrityViolationException.class);
+		when(customerRepository.saveAndFlush(Mockito.any(Customer.class))).thenThrow(
+			DataIntegrityViolationException.class);
 
 		// when
 		SignUpCustomerCommand command =
@@ -75,6 +75,6 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 		// then
 		Assertions.assertThrows(DuplicateEmailException.class, () -> service.signUp(command));
 		then(payAccountRepository).should().save(Mockito.any(PayAccount.class));
-		then(customerRepository).should().save(Mockito.any(Customer.class));
+		then(customerRepository).should().saveAndFlush(Mockito.any(Customer.class));
 	}
 }

--- a/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
+++ b/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
@@ -41,7 +41,7 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 
 	@Test
 	@DisplayName("구매자 회원가입 테스트")
-	void testSignUp() throws InvalidCreationException, DuplicateEmailException {
+	void testSignUp() {
 		// given
 		given(passwordEncoder.encode(Mockito.anyString())).willReturn("password");
 		PayAccount payAccount = createPayAccount();

--- a/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
+++ b/src/test/java/camp/woowak/lab/customer/service/SignUpCustomerServiceTest.java
@@ -2,6 +2,8 @@ package camp.woowak.lab.customer.service;
 
 import static org.mockito.BDDMockito.*;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +22,6 @@ import camp.woowak.lab.customer.service.command.SignUpCustomerCommand;
 import camp.woowak.lab.fixture.CustomerFixture;
 import camp.woowak.lab.payaccount.domain.PayAccount;
 import camp.woowak.lab.payaccount.repository.PayAccountRepository;
-import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,9 +45,10 @@ class SignUpCustomerServiceTest implements CustomerFixture {
 		// given
 		given(passwordEncoder.encode(Mockito.anyString())).willReturn("password");
 		PayAccount payAccount = createPayAccount();
-		Customer customer = createCustomer(payAccount, new NoOpPasswordEncoder());
+		Customer customerMock = Mockito.mock(Customer.class);
 		given(payAccountRepository.save(Mockito.any(PayAccount.class))).willReturn(payAccount);
-		given(customerRepository.save(Mockito.any(Customer.class))).willReturn(customer);
+		given(customerRepository.save(Mockito.any(Customer.class))).willReturn(customerMock);
+		when(customerMock.getId()).thenReturn(UUID.randomUUID());
 
 		// when
 		SignUpCustomerCommand command =

--- a/src/test/java/camp/woowak/lab/payaccount/service/PayAccountChargeServiceTest.java
+++ b/src/test/java/camp/woowak/lab/payaccount/service/PayAccountChargeServiceTest.java
@@ -3,6 +3,7 @@ package camp.woowak.lab.payaccount.service;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -71,7 +72,7 @@ class PayAccountChargeServiceTest {
 		@DisplayName("없는 AccountId를 호출하면 NotFoundAccountException을 던진다. 잔고는 유지된다.")
 		void withdrawAccountNotFound() {
 			//given
-			Long unknownAccountId = Long.MAX_VALUE;
+			UUID unknownAccountId = UUID.randomUUID();
 			long amount = 100L;
 			PayAccountChargeCommand command = new PayAccountChargeCommand(unknownAccountId, amount);
 

--- a/src/test/java/camp/woowak/lab/web/api/PayAccountApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/PayAccountApiControllerTest.java
@@ -136,7 +136,7 @@ class PayAccountApiControllerTest {
 		void notExistsAccountIdTest() throws Exception {
 			//given
 			long amount = 1000L;
-			Long notExistsId = Long.MAX_VALUE;
+			UUID notExistsId = UUID.randomUUID();
 			MockHttpSession notExistsSession = new MockHttpSession();
 			notExistsSession.setAttribute(SessionConst.SESSION_CUSTOMER_KEY, new LoginCustomer(notExistsId));
 			PayAccountChargeRequest command = new PayAccountChargeRequest(amount);

--- a/src/test/java/camp/woowak/lab/web/api/PayAccountApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/PayAccountApiControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,9 +103,9 @@ class PayAccountApiControllerTest {
 
 			//when & then
 			mvc.perform(post(BASE_URL)
-							.contentType(MediaType.APPLICATION_JSON_VALUE)
-							.content(objectMapper.writeValueAsBytes(command))
-							.session(session))
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(objectMapper.writeValueAsBytes(command))
+					.session(session))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
 				.andExpect(jsonPath("$.data.balance").value(amount + originBalance));
@@ -122,9 +123,9 @@ class PayAccountApiControllerTest {
 
 			//when & then
 			ResultActions actions = mvc.perform(post(BASE_URL)
-													.contentType(MediaType.APPLICATION_JSON_VALUE)
-													.content(objectMapper.writeValueAsBytes(command))
-													.session(session))
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(objectMapper.writeValueAsBytes(command))
+					.session(session))
 				.andDo(print())
 				.andExpect(status().isBadRequest());
 
@@ -143,9 +144,9 @@ class PayAccountApiControllerTest {
 
 			//when & then
 			ResultActions actions = mvc.perform(post(BASE_URL)
-													.contentType(MediaType.APPLICATION_JSON_VALUE)
-													.content(objectMapper.writeValueAsBytes(command))
-													.session(notExistsSession))
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(objectMapper.writeValueAsBytes(command))
+					.session(notExistsSession))
 				.andExpect(status().isNotFound());
 
 			validateErrorResponseWithErrorCode(actions, PayAccountErrorCode.ACCOUNT_NOT_FOUND);
@@ -159,9 +160,9 @@ class PayAccountApiControllerTest {
 
 			//when & then
 			ResultActions actions = mvc.perform(post(BASE_URL)
-													.contentType(MediaType.APPLICATION_JSON_VALUE)
-													.content(objectMapper.writeValueAsBytes(command))
-													.session(session))
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(objectMapper.writeValueAsBytes(command))
+					.session(session))
 				.andExpect(status().isBadRequest());
 
 			verificationPersistedBalance(payAccount.getId(), originBalance);
@@ -176,9 +177,9 @@ class PayAccountApiControllerTest {
 
 			//when & then
 			ResultActions actions = mvc.perform(post(BASE_URL)
-													.contentType(MediaType.APPLICATION_JSON_VALUE)
-													.content(objectMapper.writeValueAsBytes(command))
-													.session(session))
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(objectMapper.writeValueAsBytes(command))
+					.session(session))
 				.andExpect(status().isBadRequest());
 
 			validateErrorResponseWithErrorCode(actions, PayAccountErrorCode.INVALID_TRANSACTION_AMOUNT);

--- a/src/test/java/camp/woowak/lab/web/api/customer/CustomerApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/customer/CustomerApiControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,9 +40,10 @@ class CustomerApiControllerTest {
 	@DisplayName("구매자 회원가입 테스트 - 성공")
 	void testSignUpCustomer() throws Exception {
 		// given
+		String customerId = UUID.randomUUID().toString();
 		SignUpCustomerRequest request = new SignUpCustomerRequest("name", "email@test.com", "password123",
 			"010-1234-5678");
-		given(signUpCustomerService.signUp(any())).willReturn(1L);
+		given(signUpCustomerService.signUp(any())).willReturn(customerId);
 
 		// when & then
 		mockMvc.perform(post("/customers")


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #40 
### Discussion Link - #36 

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- Customer: id 값을 UUID 로 변경
- 기존 Customer id를 사용한 Service, DTO, test: 사용된 Long 타입을 UUID 또는 String 으로 변경
<br>

## 💡 이런 고민을 했어요.

- 기존 Long Type은 AUTO_INCREMENT 를 위해 db를 참조해야하므로 쓰기지연이 발생하지 않는다. 하지만, UUID 는 hibernate 에서 생성한 uuid를 직접 넣기 때문에 쓰기지연이 발생한다. 따라서, 그냥 save() 를 사용할 경우 Service 층에서 DataIntegrityViolationException을 잡지 못하고 상위 계층으로 넘어간다.
> 해결방안: saveAndFlush() 를 사용한다.
- Service 에서 Controller 로 id 를 전달할 때 UUID로 전달하냐 String 으로 전달하냐
> String 을 전달하는 게 더 명확한 것 같음

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
