### PR TITLE
[feat] 장바구니 담기 구현

### DIFF
--- a/src/main/java/camp/woowak/lab/cart/domain/Cart.java
+++ b/src/main/java/camp/woowak/lab/cart/domain/Cart.java
@@ -1,9 +1,16 @@
 package camp.woowak.lab.cart.domain;
 
+import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import camp.woowak.lab.cart.exception.OtherStoreMenuException;
+import camp.woowak.lab.cart.exception.StoreNotOpenException;
 import camp.woowak.lab.menu.domain.Menu;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreTime;
 import lombok.Getter;
 
 @Getter
@@ -19,5 +26,36 @@ public class Cart {
 	public Cart(Long customerId) {
 		this.customerId = customerId;
 		this.menuList = new LinkedList<>();
+	}
+
+	public void addMenu(Menu menu) {
+		Store store = menu.getStore();
+		validateOtherStore(store.getId());
+		validateStoreOpenTime(store);
+	}
+
+	private void validateStoreOpenTime(Store store) {
+		if (!store.isOpen()) {
+			StoreTime storeTime = store.getStoreTime();
+			LocalDateTime openTime = storeTime.getStartTime();
+			LocalDateTime closeTime = storeTime.getEndTime();
+			LocalDateTime now = LocalDateTime.now();
+			throw new StoreNotOpenException(
+				"store does not open in " + now + ", workingTime = " + openTime + " ~ " + closeTime);
+		}
+	}
+
+	private void validateOtherStore(Long menuStoreId) {
+		Set<Long> storeIds = getStoreIds();
+		if (!(storeIds.isEmpty() || storeIds.contains(menuStoreId)))
+			throw new OtherStoreMenuException("can not add other store. storeId = " + menuStoreId);
+	}
+
+	private Set<Long> getStoreIds() {
+		return this.menuList.stream()
+			.map(Menu::getStore)
+			.mapToLong(Store::getId)
+			.boxed()
+			.collect(Collectors.toSet());
 	}
 }

--- a/src/main/java/camp/woowak/lab/cart/domain/Cart.java
+++ b/src/main/java/camp/woowak/lab/cart/domain/Cart.java
@@ -1,0 +1,21 @@
+package camp.woowak.lab.cart.domain;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import camp.woowak.lab.menu.domain.Menu;
+
+public class Cart {
+	private Long customerId;
+	private List<Menu> menuList;
+
+	/**
+	 * 생성될 때 무조건 cart가 비어있도록 구현
+	 *
+	 * @param customerId 장바구니 소유주의 ID값입니다.
+	 */
+	public Cart(Long customerId) {
+		this.customerId = customerId;
+		this.menuList = new LinkedList<>();
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/domain/Cart.java
+++ b/src/main/java/camp/woowak/lab/cart/domain/Cart.java
@@ -32,6 +32,8 @@ public class Cart {
 		Store store = menu.getStore();
 		validateOtherStore(store.getId());
 		validateStoreOpenTime(store);
+
+		this.menuList.add(menu);
 	}
 
 	private void validateStoreOpenTime(Store store) {

--- a/src/main/java/camp/woowak/lab/cart/domain/Cart.java
+++ b/src/main/java/camp/woowak/lab/cart/domain/Cart.java
@@ -4,7 +4,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import camp.woowak.lab.menu.domain.Menu;
+import lombok.Getter;
 
+@Getter
 public class Cart {
 	private Long customerId;
 	private List<Menu> menuList;

--- a/src/main/java/camp/woowak/lab/cart/exception/CartErrorCode.java
+++ b/src/main/java/camp/woowak/lab/cart/exception/CartErrorCode.java
@@ -1,0 +1,34 @@
+package camp.woowak.lab.cart.exception;
+
+import org.springframework.http.HttpStatus;
+
+import camp.woowak.lab.common.exception.ErrorCode;
+
+public enum CartErrorCode implements ErrorCode {
+	;
+
+	private final int status;
+	private final String errorCode;
+	private final String message;
+
+	CartErrorCode(HttpStatus status, String errorCode, String message) {
+		this.status = status.value();
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/exception/CartErrorCode.java
+++ b/src/main/java/camp/woowak/lab/cart/exception/CartErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 import camp.woowak.lab.common.exception.ErrorCode;
 
 public enum CartErrorCode implements ErrorCode {
-	;
+	MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "ca_1_1", "해당 메뉴가 존재하지 않습니다."),
+	OTHER_STORE_MENU(HttpStatus.BAD_REQUEST,"ca_1_2","다른 매장의 메뉴는 등록할 수 없습니다."),
+	STORE_NOT_OPEN(HttpStatus.BAD_REQUEST,"ca_1_3","주문 가능한 시간이 아닙니다.");
 
 	private final int status;
 	private final String errorCode;

--- a/src/main/java/camp/woowak/lab/cart/exception/MenuNotFoundException.java
+++ b/src/main/java/camp/woowak/lab/cart/exception/MenuNotFoundException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.cart.exception;
+
+import camp.woowak.lab.common.exception.NotFoundException;
+
+public class MenuNotFoundException extends NotFoundException {
+	public MenuNotFoundException(String message) {
+		super(CartErrorCode.MENU_NOT_FOUND, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/exception/OtherStoreMenuException.java
+++ b/src/main/java/camp/woowak/lab/cart/exception/OtherStoreMenuException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.cart.exception;
+
+import camp.woowak.lab.common.exception.BadRequestException;
+
+public class OtherStoreMenuException extends BadRequestException {
+	public OtherStoreMenuException(String message) {
+		super(CartErrorCode.OTHER_STORE_MENU, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/exception/StoreNotOpenException.java
+++ b/src/main/java/camp/woowak/lab/cart/exception/StoreNotOpenException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.cart.exception;
+
+import camp.woowak.lab.common.exception.BadRequestException;
+
+public class StoreNotOpenException extends BadRequestException {
+	public StoreNotOpenException(String message) {
+		super(CartErrorCode.STORE_NOT_OPEN, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/repository/CartRepository.java
+++ b/src/main/java/camp/woowak/lab/cart/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package camp.woowak.lab.cart.repository;
+
+import java.util.Optional;
+
+import camp.woowak.lab.cart.domain.Cart;
+
+public interface CartRepository {
+	Optional<Cart> findByCustomerId(Long customerId);
+
+	Cart save(Cart cart);
+}

--- a/src/main/java/camp/woowak/lab/cart/repository/CartRepository.java
+++ b/src/main/java/camp/woowak/lab/cart/repository/CartRepository.java
@@ -8,4 +8,6 @@ public interface CartRepository {
 	Optional<Cart> findByCustomerId(Long customerId);
 
 	Cart save(Cart cart);
+
+	void delete(Cart cart);
 }

--- a/src/main/java/camp/woowak/lab/cart/repository/InMemoryCartRepository.java
+++ b/src/main/java/camp/woowak/lab/cart/repository/InMemoryCartRepository.java
@@ -27,4 +27,9 @@ public class InMemoryCartRepository implements CartRepository {
 
 		return cart;
 	}
+
+	@Override
+	public void delete(Cart cart) {
+		cartMap.remove(cart.getCustomerId());
+	}
 }

--- a/src/main/java/camp/woowak/lab/cart/repository/InMemoryCartRepository.java
+++ b/src/main/java/camp/woowak/lab/cart/repository/InMemoryCartRepository.java
@@ -1,0 +1,30 @@
+package camp.woowak.lab.cart.repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+
+import camp.woowak.lab.cart.domain.Cart;
+
+/**
+ * TODO : Null체크에 대한 Validation
+ */
+@Repository
+public class InMemoryCartRepository implements CartRepository {
+	private static final Map<Long, Cart> cartMap = new ConcurrentHashMap<>();
+
+	@Override
+	public Optional<Cart> findByCustomerId(Long customerId) {
+		return Optional.ofNullable(cartMap.get(customerId));
+	}
+
+	@Override
+	public Cart save(Cart cart) {
+		Long customerId = cart.getCustomerId();
+		cartMap.put(customerId, cart);
+
+		return cart;
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/service/CartService.java
+++ b/src/main/java/camp/woowak/lab/cart/service/CartService.java
@@ -31,6 +31,7 @@ public class CartService {
 			.orElseThrow(() -> new MenuNotFoundException(command.menuId() + " not found"));
 
 		customerCart.addMenu(menu);
+		cartRepository.save(customerCart);
 	}
 
 	private Cart getCart(String customerId) {

--- a/src/main/java/camp/woowak/lab/cart/service/CartService.java
+++ b/src/main/java/camp/woowak/lab/cart/service/CartService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import camp.woowak.lab.cart.domain.Cart;
 import camp.woowak.lab.cart.exception.MenuNotFoundException;
 import camp.woowak.lab.cart.repository.CartRepository;
+import camp.woowak.lab.cart.service.command.AddCartCommand;
 import camp.woowak.lab.menu.domain.Menu;
 import camp.woowak.lab.menu.repository.MenuRepository;
 
@@ -23,11 +24,11 @@ public class CartService {
 	 * @throws camp.woowak.lab.cart.exception.OtherStoreMenuException 다른 가게의 메뉴를 담은 경우 도메인에서 발생
 	 * @throws camp.woowak.lab.cart.exception.StoreNotOpenException   해당 가게가 열려있지 않은 경우 발생
 	 */
-	public void addMenu(Long customerId, Long menuId) {
-		Cart customerCart = getCart(customerId);
+	public void addMenu(AddCartCommand command) {
+		Cart customerCart = getCart(command.customerId());
 
-		Menu menu = menuRepository.findByIdWithStore(menuId)
-			.orElseThrow(() -> new MenuNotFoundException(menuId + " not found"));
+		Menu menu = menuRepository.findByIdWithStore(command.menuId())
+			.orElseThrow(() -> new MenuNotFoundException(command.menuId() + " not found"));
 
 		customerCart.addMenu(menu);
 	}

--- a/src/main/java/camp/woowak/lab/cart/service/CartService.java
+++ b/src/main/java/camp/woowak/lab/cart/service/CartService.java
@@ -1,0 +1,39 @@
+package camp.woowak.lab.cart.service;
+
+import org.springframework.stereotype.Service;
+
+import camp.woowak.lab.cart.domain.Cart;
+import camp.woowak.lab.cart.exception.MenuNotFoundException;
+import camp.woowak.lab.cart.repository.CartRepository;
+import camp.woowak.lab.menu.domain.Menu;
+import camp.woowak.lab.menu.repository.MenuRepository;
+
+@Service
+public class CartService {
+	private final CartRepository cartRepository;
+	private final MenuRepository menuRepository;
+
+	public CartService(CartRepository cartRepository, MenuRepository menuRepository) {
+		this.cartRepository = cartRepository;
+		this.menuRepository = menuRepository;
+	}
+
+	/**
+	 * @throws MenuNotFoundException                                  메뉴가 존재하지 않는 경우
+	 * @throws camp.woowak.lab.cart.exception.OtherStoreMenuException 다른 가게의 메뉴를 담은 경우 도메인에서 발생
+	 * @throws camp.woowak.lab.cart.exception.StoreNotOpenException   해당 가게가 열려있지 않은 경우 발생
+	 */
+	public void addMenu(Long customerId, Long menuId) {
+		Cart customerCart = getCart(customerId);
+
+		Menu menu = menuRepository.findByIdWithStore(menuId)
+			.orElseThrow(() -> new MenuNotFoundException(menuId + " not found"));
+
+		customerCart.addMenu(menu);
+	}
+
+	private Cart getCart(Long customerId) {
+		return cartRepository.findByCustomerId(customerId)
+			.orElse(cartRepository.save(new Cart(customerId)));
+	}
+}

--- a/src/main/java/camp/woowak/lab/cart/service/command/AddCartCommand.java
+++ b/src/main/java/camp/woowak/lab/cart/service/command/AddCartCommand.java
@@ -1,0 +1,7 @@
+package camp.woowak.lab.cart.service.command;
+
+public record AddCartCommand(
+	Long customerId,
+	Long menuId
+) {
+}

--- a/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
@@ -4,4 +4,8 @@ public class NotFoundException extends HttpStatusException {
 	public NotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}
+
+	public NotFoundException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
 }

--- a/src/main/java/camp/woowak/lab/menu/domain/Menu.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/Menu.java
@@ -29,5 +29,12 @@ public class Menu {
 	private int price;
 
 	@Column
-	private int stock;
+	private int quantity;
+
+	public Menu(Store store, String name, int price, int quantity) {
+		this.store = store;
+		this.name = name;
+		this.price = price;
+		this.quantity = quantity;
+	}
 }

--- a/src/main/java/camp/woowak/lab/menu/domain/Menu.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/Menu.java
@@ -28,13 +28,9 @@ public class Menu {
 	@Column
 	private int price;
 
-	@Column
-	private int quantity;
-
-	public Menu(Store store, String name, int price, int quantity) {
+	public Menu(Store store, String name, int price) {
 		this.store = store;
 		this.name = name;
 		this.price = price;
-		this.quantity = quantity;
 	}
 }

--- a/src/main/java/camp/woowak/lab/menu/domain/Menu.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/Menu.java
@@ -1,18 +1,33 @@
 package camp.woowak.lab.menu.domain;
 
 import camp.woowak.lab.store.domain.Store;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Menu {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Store store;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column
+	private int price;
+
+	@Column
+	private int stock;
 }

--- a/src/main/java/camp/woowak/lab/menu/repository/MenuRepository.java
+++ b/src/main/java/camp/woowak/lab/menu/repository/MenuRepository.java
@@ -1,0 +1,14 @@
+package camp.woowak.lab.menu.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import camp.woowak.lab.menu.domain.Menu;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+	@Query("SELECT m from Menu m join fetch Store s on m.store = s where m.id = :id")
+	Optional<Menu> findByIdWithStore(@Param("id") Long id);
+}

--- a/src/main/java/camp/woowak/lab/menu/repository/MenuRepository.java
+++ b/src/main/java/camp/woowak/lab/menu/repository/MenuRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 import camp.woowak.lab.menu.domain.Menu;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-	@Query("SELECT m from Menu m join fetch Store s on m.store = s where m.id = :id")
+	@Query("SELECT m FROM Menu m JOIN FETCH m.store WHERE m.id = :id")
 	Optional<Menu> findByIdWithStore(@Param("id") Long id);
 }

--- a/src/main/java/camp/woowak/lab/store/domain/Store.java
+++ b/src/main/java/camp/woowak/lab/store/domain/Store.java
@@ -64,4 +64,12 @@ public class Store {
 		this.storeTime = new StoreTime(startTime, endTime);
 	}
 
+	public boolean isOpen() {
+		LocalDateTime openTime = storeTime.getStartTime();
+		LocalDateTime closeTime = storeTime.getEndTime();
+
+		LocalDateTime now = LocalDateTime.now();
+
+		return (now.isEqual(openTime) || now.isAfter(openTime)) && now.isBefore(closeTime);
+	}
 }

--- a/src/main/java/camp/woowak/lab/store/domain/Store.java
+++ b/src/main/java/camp/woowak/lab/store/domain/Store.java
@@ -14,10 +14,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Store {
 
 	@Id

--- a/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
+++ b/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
@@ -5,10 +5,12 @@ import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class StoreTime {
 
 	@Column(nullable = false)

--- a/src/main/java/camp/woowak/lab/web/api/cart/CartApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/cart/CartApiController.java
@@ -2,6 +2,7 @@ package camp.woowak.lab.web.api.cart;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import camp.woowak.lab.cart.service.CartService;
@@ -12,7 +13,8 @@ import camp.woowak.lab.web.dto.request.cart.AddCartRequest;
 import camp.woowak.lab.web.dto.response.cart.AddCartResponse;
 import lombok.extern.slf4j.Slf4j;
 
-@RestController("/cart")
+@RestController
+@RequestMapping("/cart")
 @Slf4j
 public class CartApiController {
 	private final CartService cartService;

--- a/src/main/java/camp/woowak/lab/web/api/cart/CartApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/cart/CartApiController.java
@@ -1,0 +1,34 @@
+package camp.woowak.lab.web.api.cart;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import camp.woowak.lab.cart.service.CartService;
+import camp.woowak.lab.cart.service.command.AddCartCommand;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import camp.woowak.lab.web.dto.request.cart.AddCartRequest;
+import camp.woowak.lab.web.dto.response.cart.AddCartResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController("/cart")
+@Slf4j
+public class CartApiController {
+	private final CartService cartService;
+
+	public CartApiController(CartService cartService) {
+		this.cartService = cartService;
+	}
+
+	@PostMapping
+	public AddCartResponse addCart(
+		@AuthenticationPrincipal LoginCustomer loginCustomer,
+		@RequestBody AddCartRequest addCartRequest) {
+		AddCartCommand command = new AddCartCommand(loginCustomer.getId(), addCartRequest.menuId());
+		cartService.addMenu(command);
+
+		log.info("Customer({}) add Menu({}) in Cart", loginCustomer.getId(), addCartRequest.menuId());
+		return new AddCartResponse(true);
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/api/cart/CartApiControllerAdvice.java
+++ b/src/main/java/camp/woowak/lab/web/api/cart/CartApiControllerAdvice.java
@@ -1,0 +1,31 @@
+package camp.woowak.lab.web.api.cart;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import camp.woowak.lab.common.advice.DomainExceptionHandler;
+import camp.woowak.lab.common.exception.BadRequestException;
+import camp.woowak.lab.common.exception.ErrorCode;
+import camp.woowak.lab.common.exception.HttpStatusException;
+import lombok.extern.slf4j.Slf4j;
+
+@DomainExceptionHandler
+@Slf4j
+public class CartApiControllerAdvice {
+	@ExceptionHandler(value = {BadRequestException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ProblemDetail badRequestException(BadRequestException e) {
+		log.warn("Bad Request", e);
+		return getProblemDetail(e, HttpStatus.BAD_REQUEST);
+	}
+
+	private ProblemDetail getProblemDetail(HttpStatusException exception, HttpStatus httpStatus) {
+		ErrorCode errorCode = exception.errorCode();
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(httpStatus, errorCode.getMessage());
+		problemDetail.setProperty("errorCode", errorCode.getErrorCode());
+
+		return problemDetail;
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/api/cart/CartApiControllerAdvice.java
+++ b/src/main/java/camp/woowak/lab/web/api/cart/CartApiControllerAdvice.java
@@ -9,6 +9,7 @@ import camp.woowak.lab.common.advice.DomainExceptionHandler;
 import camp.woowak.lab.common.exception.BadRequestException;
 import camp.woowak.lab.common.exception.ErrorCode;
 import camp.woowak.lab.common.exception.HttpStatusException;
+import camp.woowak.lab.common.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 
 @DomainExceptionHandler
@@ -19,6 +20,13 @@ public class CartApiControllerAdvice {
 	public ProblemDetail badRequestException(BadRequestException e) {
 		log.warn("Bad Request", e);
 		return getProblemDetail(e, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = {NotFoundException.class})
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ProblemDetail notFoundException(NotFoundException e) {
+		log.warn("Not Found", e);
+		return getProblemDetail(e, HttpStatus.NOT_FOUND);
 	}
 
 	private ProblemDetail getProblemDetail(HttpStatusException exception, HttpStatus httpStatus) {

--- a/src/main/java/camp/woowak/lab/web/dto/request/cart/AddCartRequest.java
+++ b/src/main/java/camp/woowak/lab/web/dto/request/cart/AddCartRequest.java
@@ -1,0 +1,6 @@
+package camp.woowak.lab.web.dto.request.cart;
+
+public record AddCartRequest(
+	Long menuId
+) {
+}

--- a/src/main/java/camp/woowak/lab/web/dto/response/cart/AddCartResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/cart/AddCartResponse.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.web.dto.response.cart;
+
+/**
+ * TODO : 카트가 추가된 뒤 response를 뭘 보내야할지 애매해서 success만 보냄.
+ */
+public record AddCartResponse(
+	boolean success
+) {
+}

--- a/src/test/java/camp/woowak/lab/cart/repository/InMemoryCartRepositoryTest.java
+++ b/src/test/java/camp/woowak/lab/cart/repository/InMemoryCartRepositoryTest.java
@@ -1,0 +1,94 @@
+package camp.woowak.lab.cart.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import camp.woowak.lab.cart.domain.Cart;
+
+@DisplayName("InMemoryCartRepository 클래스")
+class InMemoryCartRepositoryTest {
+	private CartRepository repository;
+	private static final Long CUSTOMER_ID_EXIST = 1L;
+	private static final Long CUSTOMER_ID_NOT_EXIST = 2L;
+	private Cart cart;
+
+	@BeforeEach
+	void setUp() {
+		repository = new InMemoryCartRepository();
+		cart = new Cart(CUSTOMER_ID_EXIST);
+		repository.save(cart);
+	}
+
+	@AfterEach
+	void clear(){
+		repository.delete(cart);
+	}
+
+	@Nested
+	@DisplayName("findByCustomerId 메서드")
+	class FindByCustomerIdTest{
+		@Test
+		@DisplayName("customerId에 해당하는 Cart가 없으면 Optional(null)을 반환한다.")
+		void NullReturnWhenCustomerIdNotExists(){
+			//when
+			Optional<Cart> foundCart = repository.findByCustomerId(CUSTOMER_ID_NOT_EXIST);
+
+			//then
+			assertThat(foundCart).isEmpty();
+		}
+
+		@Test
+		@DisplayName("customerId에 해당하는 Cart가 있으면 해당 Cart를 반환한다.")
+		void cartReturnWhenCustomerIdExists(){
+			//when
+			Optional<Cart> foundCart = repository.findByCustomerId(CUSTOMER_ID_EXIST);
+
+			//then
+			assertThat(foundCart).hasValue(cart);
+		}
+	}
+
+	@Nested
+	@DisplayName("save 메서드")
+	class SaveTest{
+		@Test
+		@DisplayName("cart를 저장할 수 있다.")
+		void saveTest(){
+			//given
+			Cart newCart = new Cart(CUSTOMER_ID_NOT_EXIST);
+
+			//when
+			Cart savedCart = repository.save(newCart);
+
+			//then
+			assertThat(newCart).isEqualTo(savedCart);
+			Optional<Cart> foundCart = repository.findByCustomerId(CUSTOMER_ID_NOT_EXIST);
+			assertThat(foundCart).hasValue(newCart);
+
+			//tear down
+			repository.delete(savedCart);
+		}
+	}
+
+	@Nested
+	@DisplayName("delete 메서드")
+	class DeleteTest{
+		@Test
+		@DisplayName("존재하는 customerId의 cart를 삭제할 수 있다.")
+		void deleteTest(){
+			//when
+			repository.delete(cart);
+
+			//then
+			Optional<Cart> foundCart = repository.findByCustomerId(CUSTOMER_ID_EXIST);
+			assertThat(foundCart).isEmpty();
+		}
+	}
+}

--- a/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
+++ b/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
@@ -1,0 +1,184 @@
+package camp.woowak.lab.cart.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import camp.woowak.lab.cart.domain.Cart;
+import camp.woowak.lab.cart.exception.MenuNotFoundException;
+import camp.woowak.lab.cart.exception.OtherStoreMenuException;
+import camp.woowak.lab.cart.exception.StoreNotOpenException;
+import camp.woowak.lab.cart.repository.CartRepository;
+import camp.woowak.lab.cart.service.command.AddCartCommand;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import camp.woowak.lab.menu.domain.Menu;
+import camp.woowak.lab.menu.repository.MenuRepository;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.payaccount.repository.PayAccountRepository;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreCategory;
+import camp.woowak.lab.store.repository.StoreCategoryRepository;
+import camp.woowak.lab.store.repository.StoreRepository;
+import camp.woowak.lab.vendor.domain.Vendor;
+import camp.woowak.lab.vendor.repository.VendorRepository;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import camp.woowak.lab.web.authentication.PasswordEncoder;
+import jakarta.transaction.Transactional;
+
+@DisplayName("CartService 클래스")
+@SpringBootTest
+@Transactional
+class CartServiceTest {
+	@Autowired
+	private PayAccountRepository payAccountRepository;
+	@Autowired
+	private CartRepository cartRepository;
+	@Autowired
+	private MenuRepository menuRepository;
+	@Autowired
+	private StoreCategoryRepository storeCategoryRepository;
+	@Autowired
+	private StoreRepository storeRepository;
+	@Autowired
+	private VendorRepository vendorRepository;
+	@Autowired
+	private CustomerRepository customerRepository;
+
+	@Autowired
+	private CartService cartService;
+
+	private static final int minOrderPrice = 8000;
+	private static final LocalDateTime startTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+	private static final LocalDateTime endTime = LocalDateTime.now().plusMinutes(10).withSecond(0).withNano(0);
+
+	private Customer customer;
+	private Menu menu;
+	private Store store;
+	private Vendor vendor;
+
+	@BeforeEach
+	void setUp() {
+		customer = createCustomer();
+
+		vendor = createVendor();
+
+		store = createStore(vendor, "중화반점", minOrderPrice, startTime, endTime);
+
+		menu = createMenu(store, "짜장면", 90000, 10);
+	}
+
+	@Nested
+	@DisplayName("addMenu 메서드")
+	class AddMenu {
+		@Test
+		@DisplayName("존재하는 메뉴를 장바구니에 추가할 수 있다.")
+		void addMenuInCartWhenMenuExists() {
+			//given
+			AddCartCommand command = new AddCartCommand(customer.getId(), menu.getId());
+
+			//when
+			cartService.addMenu(command);
+
+			//then
+			Optional<Cart> cart = cartRepository.findByCustomerId(customer.getId());
+			assertThat(cart).isPresent();
+			Cart cartList = cart.get();
+			assertThat(cartList.getMenuList()).contains(menu);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 메뉴를 장바구니에 추가하면 MenuNotFoundException을 던진다.")
+		void addMenuInCartWhenMenuDoesNotExist() {
+			//given
+			Long notExistsMenuId = Long.MAX_VALUE;
+			AddCartCommand command = new AddCartCommand(customer.getId(), notExistsMenuId);
+
+			//when & then
+			assertThatThrownBy(() -> cartService.addMenu(command))
+				.isExactlyInstanceOf(MenuNotFoundException.class);
+		}
+
+		@Test
+		@DisplayName("가게가 열려있지 않다면 장바구니에 물건을 담을 수 없다.")
+		void throwExceptionWhenAddMenuInCartWithClosedStoresMenu() {
+			//given
+			LocalDateTime startTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+			LocalDateTime endTime = LocalDateTime.now().minusMinutes(1).withSecond(0).withNano(0);
+			Store closedStore = createStore(vendor, "오픈 전의 중화반점", 8000, startTime, endTime);
+			Menu menu = createMenu(closedStore, "오픈시간이 아니라 담을 수 없는 메뉴", 1000, 10);
+
+			AddCartCommand command = new AddCartCommand(customer.getId(), menu.getId());
+
+			//when & then
+			assertThatThrownBy(() -> cartService.addMenu(command))
+				.isExactlyInstanceOf(StoreNotOpenException.class);
+		}
+
+		@Test
+		@DisplayName("다른 가게의 메뉴를 함께 담을 수 없다.")
+		void throwExceptionWhenAddMenuInCartWithOtherStoresMenu() {
+			//given
+			Store otherStore = createStore(vendor, "다른집", 8000, startTime, endTime);
+			Menu otherStoresMenu = createMenu(otherStore, "다른집 짜장면", 9000, 10);
+
+			AddCartCommand command1 = new AddCartCommand(customer.getId(), menu.getId());
+			cartService.addMenu(command1);
+
+			//when & then
+			AddCartCommand otherStoreCommand = new AddCartCommand(customer.getId(), otherStoresMenu.getId());
+			assertThatThrownBy(() -> cartService.addMenu(otherStoreCommand))
+				.isExactlyInstanceOf(OtherStoreMenuException.class);
+		}
+	}
+
+	private Menu createMenu(Store store, String name, int price, int quantity) {
+		Menu menu1 = new Menu(store, name, price, quantity);
+		menuRepository.saveAndFlush(menu1);
+
+		return menu1;
+	}
+
+	private Store createStore(Vendor vendor, String name, int minOrderPrice, LocalDateTime startTime,
+							  LocalDateTime endTime) {
+		StoreCategory storeCategory = new StoreCategory("중국집");
+		storeCategoryRepository.saveAndFlush(storeCategory);
+
+		Store store1 = new Store(vendor, storeCategory, name, "송파", "010-1111-2222", minOrderPrice, startTime,
+			endTime);
+		storeRepository.saveAndFlush(store1);
+
+		return store1;
+	}
+
+	private Customer createCustomer() {
+		PayAccount payAccount = new PayAccount();
+		payAccountRepository.save(payAccount);
+		PasswordEncoder passwordEncoder = new NoOpPasswordEncoder();
+		Customer customer1 = new Customer("customerName", "customer@example.com", "customerPassword", "010-1234-5647",
+			payAccount, passwordEncoder);
+		customerRepository.saveAndFlush(customer1);
+
+		return customer1;
+	}
+
+	private Vendor createVendor() {
+		PayAccount payAccount = new PayAccount();
+		payAccountRepository.saveAndFlush(payAccount);
+		PasswordEncoder passwordEncoder = new NoOpPasswordEncoder();
+		Vendor vendor1 = new Vendor("vendorName", "vendorEmail@example.com", "vendorPassword", "010-0000-0000",
+			payAccount,
+			passwordEncoder);
+		vendorRepository.saveAndFlush(vendor1);
+
+		return vendor1;
+	}
+}

--- a/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
+++ b/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
@@ -73,7 +73,7 @@ class CartServiceTest {
 
 		store = createStore(vendor, "중화반점", minOrderPrice, startTime, endTime);
 
-		menu = createMenu(store, "짜장면", 90000, 10);
+		menu = createMenu(store, "짜장면", 90000);
 	}
 
 	@Nested

--- a/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
+++ b/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
@@ -114,7 +114,7 @@ class CartServiceTest {
 			LocalDateTime startTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
 			LocalDateTime endTime = LocalDateTime.now().minusMinutes(1).withSecond(0).withNano(0);
 			Store closedStore = createStore(vendor, "오픈 전의 중화반점", 8000, startTime, endTime);
-			Menu menu = createMenu(closedStore, "오픈시간이 아니라 담을 수 없는 메뉴", 1000, 10);
+			Menu menu = createMenu(closedStore, "오픈시간이 아니라 담을 수 없는 메뉴", 1000);
 
 			AddCartCommand command = new AddCartCommand(customer.getId(), menu.getId());
 
@@ -128,7 +128,7 @@ class CartServiceTest {
 		void throwExceptionWhenAddMenuInCartWithOtherStoresMenu() {
 			//given
 			Store otherStore = createStore(vendor, "다른집", 8000, startTime, endTime);
-			Menu otherStoresMenu = createMenu(otherStore, "다른집 짜장면", 9000, 10);
+			Menu otherStoresMenu = createMenu(otherStore, "다른집 짜장면", 9000);
 
 			AddCartCommand command1 = new AddCartCommand(customer.getId(), menu.getId());
 			cartService.addMenu(command1);
@@ -140,8 +140,8 @@ class CartServiceTest {
 		}
 	}
 
-	private Menu createMenu(Store store, String name, int price, int quantity) {
-		Menu menu1 = new Menu(store, name, price, quantity);
+	private Menu createMenu(Store store, String name, int price) {
+		Menu menu1 = new Menu(store, name, price);
 		menuRepository.saveAndFlush(menu1);
 
 		return menu1;

--- a/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
@@ -80,7 +80,7 @@ class CartApiControllerTest {
 			customer = createCustomer();
 			vendor = createVendor();
 			Store store = createStore(vendor, "중화반점", 8000, startTime, endTime);
-			menu = createMenu(store, "짜장면", 90000, 10);
+			menu = createMenu(store, "짜장면", 90000);
 			session = new MockHttpSession();
 			session.setAttribute(SessionConst.SESSION_CUSTOMER_KEY, new LoginCustomer(customer.getId()));
 		}
@@ -124,7 +124,7 @@ class CartApiControllerTest {
 			LocalDateTime closedStartTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
 			LocalDateTime closedEndTime = LocalDateTime.now().minusMinutes(1).withSecond(0).withNano(0);
 			Store closedStore = createStore(vendor, "닫힌 가게", minOrderPrice, closedStartTime, closedEndTime);
-			Menu closedStoresMenu = createMenu(closedStore, "닫힌 가게의 메뉴", 1000, 10);
+			Menu closedStoresMenu = createMenu(closedStore, "닫힌 가게의 메뉴", 1000);
 
 			AddCartRequest request = new AddCartRequest(closedStoresMenu.getId());
 			String content = mapper.writeValueAsString(request);
@@ -144,7 +144,7 @@ class CartApiControllerTest {
 		void cantAddMenuWithOtherStoresMenu() throws Exception {
 			//given
 			Store otherStore = createStore(vendor, "옆집 가게", minOrderPrice, startTime, endTime);
-			Menu otherStoreMenu = createMenu(otherStore, "옆집 가게 메뉴", 10000, 10);
+			Menu otherStoreMenu = createMenu(otherStore, "옆집 가게 메뉴", 10000);
 
 			AddCartRequest givenRequest = new AddCartRequest(menu.getId());
 			String givenContent = mapper.writeValueAsString(givenRequest);
@@ -169,8 +169,8 @@ class CartApiControllerTest {
 		}
 	}
 
-	private Menu createMenu(Store store, String name, int price, int quantity) {
-		Menu menu1 = new Menu(store, name, price, quantity);
+	private Menu createMenu(Store store, String name, int price) {
+		Menu menu1 = new Menu(store, name, price);
 		menuRepository.saveAndFlush(menu1);
 
 		return menu1;

--- a/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
@@ -1,0 +1,220 @@
+package camp.woowak.lab.web.api.cart;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import camp.woowak.lab.cart.exception.CartErrorCode;
+import camp.woowak.lab.common.exception.ErrorCode;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import camp.woowak.lab.menu.domain.Menu;
+import camp.woowak.lab.menu.repository.MenuRepository;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.payaccount.repository.PayAccountRepository;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreCategory;
+import camp.woowak.lab.store.repository.StoreCategoryRepository;
+import camp.woowak.lab.store.repository.StoreRepository;
+import camp.woowak.lab.vendor.domain.Vendor;
+import camp.woowak.lab.vendor.repository.VendorRepository;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import camp.woowak.lab.web.authentication.PasswordEncoder;
+import camp.woowak.lab.web.dto.request.cart.AddCartRequest;
+import camp.woowak.lab.web.resolver.session.SessionConst;
+import jakarta.transaction.Transactional;
+
+@DisplayName("CartApiController 클래스")
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class CartApiControllerTest {
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private PayAccountRepository payAccountRepository;
+	@Autowired
+	private MenuRepository menuRepository;
+	@Autowired
+	private StoreCategoryRepository storeCategoryRepository;
+	@Autowired
+	private StoreRepository storeRepository;
+	@Autowired
+	private VendorRepository vendorRepository;
+	@Autowired
+	private CustomerRepository customerRepository;
+	@Autowired
+	private ObjectMapper mapper;
+
+	@Nested
+	@DisplayName("addMenu 메서드는")
+	class AddMenu {
+		private final String BASE_URL = "/cart";
+		private Customer customer;
+		private Vendor vendor;
+		private Menu menu;
+		private static final int minOrderPrice = 8000;
+		private static final LocalDateTime startTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+		private static final LocalDateTime endTime = LocalDateTime.now().plusMinutes(10).withSecond(0).withNano(0);
+		private MockHttpSession session;
+
+		@BeforeEach
+		void setUp() throws Exception {
+			customer = createCustomer();
+			vendor = createVendor();
+			Store store = createStore(vendor, "중화반점", 8000, startTime, endTime);
+			menu = createMenu(store, "짜장면", 90000, 10);
+			session = new MockHttpSession();
+			session.setAttribute(SessionConst.SESSION_CUSTOMER_KEY, new LoginCustomer(customer.getId()));
+		}
+
+		@Test
+		@DisplayName("존재하는 메뉴를 장바구니에 담을 수 있다.")
+		void addMenuWithExistsMenu() throws Exception {
+			//given
+			AddCartRequest request = new AddCartRequest(menu.getId());
+			String content = mapper.writeValueAsString(request);
+
+			//when & then
+			mvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(content).session(session))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.success").value(true));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 메뉴는 장바구니에 담을 수 없다.")
+		void cantAddMenuWithNonexistentMenu() throws Exception {
+			//given
+			AddCartRequest request = new AddCartRequest(Long.MAX_VALUE);
+			String content = mapper.writeValueAsString(request);
+
+			//when & then
+			ResultActions actions = mvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(content)
+					.session(session))
+				.andExpect(status().isNotFound());
+
+			validateErrorResponseWithErrorCode(actions, CartErrorCode.MENU_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("열리지 않은 가게의 메뉴를 장바구니에 담을 수 없다.")
+		void cantAddMenuWithClosedStoresMenu() throws Exception {
+			//given
+			LocalDateTime closedStartTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+			LocalDateTime closedEndTime = LocalDateTime.now().minusMinutes(1).withSecond(0).withNano(0);
+			Store closedStore = createStore(vendor, "닫힌 가게", minOrderPrice, closedStartTime, closedEndTime);
+			Menu closedStoresMenu = createMenu(closedStore, "닫힌 가게의 메뉴", 1000, 10);
+
+			AddCartRequest request = new AddCartRequest(closedStoresMenu.getId());
+			String content = mapper.writeValueAsString(request);
+
+			//when & then
+			ResultActions action = mvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(content)
+					.session(session))
+				.andExpect(status().isBadRequest());
+
+			validateErrorResponseWithErrorCode(action, CartErrorCode.STORE_NOT_OPEN);
+		}
+
+		@Test
+		@DisplayName("서로 다른 가게의 메뉴를 장바구니에 담을 수 없다.")
+		void cantAddMenuWithOtherStoresMenu() throws Exception {
+			//given
+			Store otherStore = createStore(vendor, "옆집 가게", minOrderPrice, startTime, endTime);
+			Menu otherStoreMenu = createMenu(otherStore, "옆집 가게 메뉴", 10000, 10);
+
+			AddCartRequest givenRequest = new AddCartRequest(menu.getId());
+			String givenContent = mapper.writeValueAsString(givenRequest);
+
+			AddCartRequest request = new AddCartRequest(otherStoreMenu.getId());
+			String content = mapper.writeValueAsString(request);
+
+			//기존에 있던 가게의 메뉴를 담아둠
+			mvc.perform(post(BASE_URL)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.content(givenContent)
+				.session(session));
+
+			//when & then
+			ResultActions actions = mvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.content(content)
+					.session(session))
+				.andExpect(status().isBadRequest());
+
+			validateErrorResponseWithErrorCode(actions, CartErrorCode.OTHER_STORE_MENU);
+		}
+	}
+
+	private Menu createMenu(Store store, String name, int price, int quantity) {
+		Menu menu1 = new Menu(store, name, price, quantity);
+		menuRepository.saveAndFlush(menu1);
+
+		return menu1;
+	}
+
+	private Store createStore(Vendor vendor, String name, int minOrderPrice, LocalDateTime startTime,
+							  LocalDateTime endTime) {
+		StoreCategory storeCategory = new StoreCategory("중국집");
+		storeCategoryRepository.saveAndFlush(storeCategory);
+
+		Store store1 = new Store(vendor, storeCategory, name, "송파", "010-1111-2222", minOrderPrice, startTime,
+			endTime);
+		storeRepository.saveAndFlush(store1);
+
+		return store1;
+	}
+
+	private Customer createCustomer() {
+		PayAccount payAccount = new PayAccount();
+		payAccountRepository.save(payAccount);
+		PasswordEncoder passwordEncoder = new NoOpPasswordEncoder();
+		Customer customer1 = new Customer("customerName", "customer@example.com", "customerPassword", "010-1234-5647",
+			payAccount, passwordEncoder);
+		customerRepository.saveAndFlush(customer1);
+
+		return customer1;
+	}
+
+	private Vendor createVendor() {
+		PayAccount payAccount = new PayAccount();
+		payAccountRepository.saveAndFlush(payAccount);
+		PasswordEncoder passwordEncoder = new NoOpPasswordEncoder();
+		Vendor vendor1 = new Vendor("vendorName", "vendorEmail@example.com", "vendorPassword", "010-0000-0000",
+			payAccount,
+			passwordEncoder);
+		vendorRepository.saveAndFlush(vendor1);
+
+		return vendor1;
+	}
+
+	private ResultActions validateErrorResponseWithErrorCode(ResultActions actions, ErrorCode errorCode) throws
+		Exception {
+		return actions.andExpect(jsonPath("$.status").value(errorCode.getStatus()))
+			.andExpect(jsonPath("$.detail").value(errorCode.getMessage()))
+			.andExpect(jsonPath("$.errorCode").value(errorCode.getErrorCode()));
+	}
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #61  #62 
### 장바구니 담기 기능 추가

- 존재하는 메뉴를 장바구니에 담을 수 있습니다.
- 서로 다른 가게의 메뉴는 담을 수 없습니다.
- 닫힌 가게의 메뉴는 담을 수 없습니다.
- 존재하지 않는 메뉴는 담을 수 없습니다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

### Menu와 Store의 @Getter 추가

<br>

## 💡 이런 고민을 했어요.

현재는 InMemory 에 저장하는 방식으로 구현함

<br>
## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
