### PR TITLE
[feat] 점주는 음식 카테고리를 등록할 수 있다

### DIFF
--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import camp.woowak.lab.common.exception.ErrorCode;
@@ -27,7 +26,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return problemDetail;
 	}
 
-	@ExceptionHandler(HttpStatusCodeException.class)
+	@ExceptionHandler(HttpStatusException.class)
 	public ProblemDetail handleException(HttpStatusException exception) {
 		log.info(exception.getMessage(), exception);
 		ErrorCode errorCode = exception.errorCode();

--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		ErrorCode errorCode = exception.errorCode();
 		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
 			HttpStatus.valueOf(errorCode.getStatus()), exception.errorCode().getMessage());
-		problemDetail.setProperty("error_code", errorCode.getErrorCode());
+		problemDetail.setProperty("errorCode", errorCode.getErrorCode());
 		return problemDetail;
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/common/advice/GlobalExceptionHandler.java
@@ -4,8 +4,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import camp.woowak.lab.common.exception.ErrorCode;
+import camp.woowak.lab.common.exception.HttpStatusException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,6 +24,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		log.error("[Unexpected Exception]", e);
 		// TODO: Notion Hook 등록
 
+		return problemDetail;
+	}
+
+	@ExceptionHandler(HttpStatusCodeException.class)
+	public ProblemDetail handleException(HttpStatusException exception) {
+		log.info(exception.getMessage(), exception);
+		ErrorCode errorCode = exception.errorCode();
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+			HttpStatus.valueOf(errorCode.getStatus()), exception.errorCode().getMessage());
+		problemDetail.setProperty("error_code", errorCode.getErrorCode());
 		return problemDetail;
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/exception/BadRequestException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/BadRequestException.java
@@ -1,6 +1,7 @@
 package camp.woowak.lab.common.exception;
 
 public class BadRequestException extends HttpStatusException {
+	@Deprecated
 	public BadRequestException(ErrorCode errorCode) {
 		super(errorCode);
 	}

--- a/src/main/java/camp/woowak/lab/common/exception/ConflictException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/ConflictException.java
@@ -1,7 +1,12 @@
 package camp.woowak.lab.common.exception;
 
 public class ConflictException extends HttpStatusException {
+	@Deprecated
 	public ConflictException(ErrorCode errorCode) {
 		super(errorCode);
+	}
+
+	public ConflictException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/exception/ForbiddenException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/ForbiddenException.java
@@ -1,7 +1,12 @@
 package camp.woowak.lab.common.exception;
 
 public class ForbiddenException extends HttpStatusException {
+	@Deprecated
 	public ForbiddenException(ErrorCode errorCode) {
 		super(errorCode);
+	}
+
+	public ForbiddenException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/exception/HttpStatusException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/HttpStatusException.java
@@ -1,6 +1,6 @@
 package camp.woowak.lab.common.exception;
 
-public class HttpStatusException extends RuntimeException {
+abstract class HttpStatusException extends RuntimeException {
 	private final ErrorCode errorCode;
 
 	@Deprecated

--- a/src/main/java/camp/woowak/lab/common/exception/HttpStatusException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/HttpStatusException.java
@@ -1,6 +1,6 @@
 package camp.woowak.lab.common.exception;
 
-abstract class HttpStatusException extends RuntimeException {
+public class HttpStatusException extends RuntimeException {
 	private final ErrorCode errorCode;
 
 	@Deprecated

--- a/src/main/java/camp/woowak/lab/common/exception/MethodNotAllowedException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/MethodNotAllowedException.java
@@ -1,7 +1,12 @@
 package camp.woowak.lab.common.exception;
 
 public class MethodNotAllowedException extends HttpStatusException {
+	@Deprecated
 	public MethodNotAllowedException(ErrorCode errorCode) {
 		super(errorCode);
+	}
+
+	public MethodNotAllowedException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/NotFoundException.java
@@ -1,6 +1,7 @@
 package camp.woowak.lab.common.exception;
 
 public class NotFoundException extends HttpStatusException {
+	@Deprecated
 	public NotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}

--- a/src/main/java/camp/woowak/lab/common/exception/UnauthorizedException.java
+++ b/src/main/java/camp/woowak/lab/common/exception/UnauthorizedException.java
@@ -1,7 +1,12 @@
 package camp.woowak.lab.common.exception;
 
 public class UnauthorizedException extends HttpStatusException {
+	@Deprecated
 	public UnauthorizedException(ErrorCode errorCode) {
 		super(errorCode);
+	}
+
+	public UnauthorizedException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/menu/domain/MenuCategory.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/MenuCategory.java
@@ -9,11 +9,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	name = "menu_category",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "unique_store_name", columnNames = {"store_id", "name"})
+	}
+)
 public class MenuCategory {
 
 	@Id
@@ -37,3 +45,4 @@ public class MenuCategory {
 		return id;
 	}
 }
+

--- a/src/main/java/camp/woowak/lab/menu/domain/MenuCategory.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/MenuCategory.java
@@ -33,4 +33,7 @@ public class MenuCategory {
 		this.name = name;
 	}
 
+	public Long getId() {
+		return id;
+	}
 }

--- a/src/main/java/camp/woowak/lab/menu/exception/DuplicateMenuCategoryException.java
+++ b/src/main/java/camp/woowak/lab/menu/exception/DuplicateMenuCategoryException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.menu.exception;
+
+import camp.woowak.lab.common.exception.BadRequestException;
+
+public class DuplicateMenuCategoryException extends BadRequestException {
+	public DuplicateMenuCategoryException(String message) {
+		super(MenuErrorCode.DUPLICATE_MENU_CATEGORY, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
+++ b/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
@@ -1,0 +1,34 @@
+package camp.woowak.lab.menu.exception;
+
+import org.springframework.http.HttpStatus;
+
+import camp.woowak.lab.common.exception.ErrorCode;
+
+public enum MenuErrorCode implements ErrorCode {
+	DUPLICATE_MENU_CATEGORY(HttpStatus.BAD_REQUEST, "m_1", "이미 생성된 카테고리입니다.");
+
+	private final int status;
+	private final String errorCode;
+	private final String message;
+
+	MenuErrorCode(HttpStatus httpStatus, String errorCode, String message) {
+		this.status = httpStatus.value();
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
+++ b/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 import camp.woowak.lab.common.exception.ErrorCode;
 
 public enum MenuErrorCode implements ErrorCode {
-	DUPLICATE_MENU_CATEGORY(HttpStatus.BAD_REQUEST, "m_1", "이미 생성된 카테고리입니다.");
+	DUPLICATE_MENU_CATEGORY(HttpStatus.BAD_REQUEST, "m_1", "이미 생성된 카테고리입니다."),
+	UNAUTHORIZED_MENU_CATEGORY_CREATION(HttpStatus.FORBIDDEN, "m_2", "점주만 카테고리를 생성할 수 있습니다.");
 
 	private final int status;
 	private final String errorCode;

--- a/src/main/java/camp/woowak/lab/menu/exception/UnauthorizedMenuCategoryCreationException.java
+++ b/src/main/java/camp/woowak/lab/menu/exception/UnauthorizedMenuCategoryCreationException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.menu.exception;
+
+import camp.woowak.lab.common.exception.UnauthorizedException;
+
+public class UnauthorizedMenuCategoryCreationException extends UnauthorizedException {
+	public UnauthorizedMenuCategoryCreationException(String message) {
+		super(MenuErrorCode.UNAUTHORIZED_MENU_CATEGORY_CREATION, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
+++ b/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
@@ -1,0 +1,41 @@
+package camp.woowak.lab.menu.service;
+
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.menu.exception.DuplicateMenuCategoryException;
+import camp.woowak.lab.menu.repository.MenuCategoryRepository;
+import camp.woowak.lab.menu.service.command.MenuCategoryRegistrationCommand;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.exception.NotFoundStoreException;
+import camp.woowak.lab.store.repository.StoreRepository;
+
+@Service
+public class MenuCategoryRegistrationService {
+	private final StoreRepository storeRepository;
+	private final MenuCategoryRepository menuCategoryRepository;
+
+	public MenuCategoryRegistrationService(StoreRepository storeRepository,
+										   MenuCategoryRepository menuCategoryRepository) {
+		this.storeRepository = storeRepository;
+		this.menuCategoryRepository = menuCategoryRepository;
+	}
+
+	public Long register(MenuCategoryRegistrationCommand cmd) {
+		Optional<Store> findStore = storeRepository.findById(cmd.storeId());
+		if (findStore.isEmpty()) {
+			throw new NotFoundStoreException("등록되지 않는 Store에는 메뉴 카테고리를 등록할 수 없습니다.");
+		}
+		Store store = findStore.get();
+		MenuCategory savedMenuCategory;
+		try {
+			savedMenuCategory = menuCategoryRepository.saveAndFlush(new MenuCategory(store, cmd.name()));
+		} catch (DataIntegrityViolationException e) {
+			throw new DuplicateMenuCategoryException("해당 Store에는 이미 같은 이름의 메뉴 카테고리가 있습니다.");
+		}
+		return savedMenuCategory.getId();
+	}
+}

--- a/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
+++ b/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import camp.woowak.lab.menu.domain.MenuCategory;
 import camp.woowak.lab.menu.exception.DuplicateMenuCategoryException;
@@ -15,6 +16,7 @@ import camp.woowak.lab.store.exception.NotFoundStoreException;
 import camp.woowak.lab.store.repository.StoreRepository;
 
 @Service
+@Transactional
 public class MenuCategoryRegistrationService {
 	private final StoreRepository storeRepository;
 	private final MenuCategoryRepository menuCategoryRepository;

--- a/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
+++ b/src/main/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationService.java
@@ -14,10 +14,13 @@ import camp.woowak.lab.menu.service.command.MenuCategoryRegistrationCommand;
 import camp.woowak.lab.store.domain.Store;
 import camp.woowak.lab.store.exception.NotFoundStoreException;
 import camp.woowak.lab.store.repository.StoreRepository;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 public class MenuCategoryRegistrationService {
+
 	private final StoreRepository storeRepository;
 	private final MenuCategoryRepository menuCategoryRepository;
 
@@ -30,16 +33,19 @@ public class MenuCategoryRegistrationService {
 	public Long register(MenuCategoryRegistrationCommand cmd) {
 		Optional<Store> findStore = storeRepository.findById(cmd.storeId());
 		if (findStore.isEmpty()) {
+			log.info("등록되지 않은 점포 {}에 메뉴 카테고리 등록을 시도했습니다.", cmd.storeId());
 			throw new NotFoundStoreException("등록되지 않는 Store에 메뉴 카테고리 생성을 시도했습니다.");
 		}
 		Store store = findStore.get();
 		if (!store.isOwnedBy(cmd.vendorId())) {
+			log.info("권한없는 사용자 {}가 점포 {}에 메뉴 카테고리 등록을 시도했습니다.", cmd.vendorId(), cmd.storeId());
 			throw new UnauthorizedMenuCategoryCreationException("권한없는 사용자가 메뉴 카테고리 등록을 시도했습니다.");
 		}
 		MenuCategory savedMenuCategory;
 		try {
 			savedMenuCategory = menuCategoryRepository.saveAndFlush(new MenuCategory(store, cmd.name()));
 		} catch (DataIntegrityViolationException e) {
+			log.info("점주 {}가 점포 {}에 중복된 이름의 메뉴 카테고리 등록을 시도했습니다.", cmd.vendorId(), cmd.storeId());
 			throw new DuplicateMenuCategoryException("같은 이름의 메뉴 카테고리 생성을 시도했습니다.");
 		}
 		return savedMenuCategory.getId();

--- a/src/main/java/camp/woowak/lab/menu/service/command/MenuCategoryRegistrationCommand.java
+++ b/src/main/java/camp/woowak/lab/menu/service/command/MenuCategoryRegistrationCommand.java
@@ -1,0 +1,10 @@
+package camp.woowak.lab.menu.service.command;
+
+import java.util.UUID;
+
+public record MenuCategoryRegistrationCommand(
+	UUID vendorId,
+	Long storeId,
+	String name
+) {
+}

--- a/src/main/java/camp/woowak/lab/store/domain/Store.java
+++ b/src/main/java/camp/woowak/lab/store/domain/Store.java
@@ -1,6 +1,7 @@
 package camp.woowak.lab.store.domain;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import camp.woowak.lab.store.exception.NotEqualsOwnerException;
 import camp.woowak.lab.vendor.domain.Vendor;
@@ -69,4 +70,7 @@ public class Store {
 		}
 	}
 
+	public boolean isOwnedBy(UUID ownerId) {
+		return owner.getId().equals(ownerId);
+	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
@@ -1,16 +1,21 @@
 package camp.woowak.lab.web.api.store;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import camp.woowak.lab.menu.service.MenuCategoryRegistrationService;
+import camp.woowak.lab.menu.service.command.MenuCategoryRegistrationCommand;
 import camp.woowak.lab.store.service.StoreRegistrationService;
 import camp.woowak.lab.store.service.dto.StoreRegistrationRequest;
 import camp.woowak.lab.vendor.domain.Vendor;
 import camp.woowak.lab.vendor.repository.VendorRepository;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import camp.woowak.lab.web.dto.request.store.MenuCategoryRegistrationRequest;
+import camp.woowak.lab.web.dto.response.store.MenuCategoryRegistrationResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -19,16 +24,26 @@ import lombok.RequiredArgsConstructor;
 public class StoreApiController {
 
 	private final StoreRegistrationService storeRegistrationService;
+	private final MenuCategoryRegistrationService menuCategoryRegistrationService;
 	private final VendorRepository vendorRepository;
 
 	// TODO: 서비스 메서드 코드 스타일 통일하면서 dtoResponse 반환하도록 수정할 예정
 	@PostMapping("/stores")
 	public ResponseEntity<Void> storeRegistration(@AuthenticationPrincipal final LoginVendor loginVendor,
-												  final @Valid @RequestBody StoreRegistrationRequest request
+												  @Valid @RequestBody final StoreRegistrationRequest request
 	) {
 		Vendor vendor = vendorRepository.findById(loginVendor.getId()).orElseThrow();
 		storeRegistrationService.storeRegistration(vendor, request);
 		return ResponseEntity.ok().build();
 	}
 
+	@PostMapping("/stores/{storeId}/category")
+	public MenuCategoryRegistrationResponse storeCategoryRegistration(@AuthenticationPrincipal LoginVendor loginVendor,
+																	  @PathVariable Long storeId,
+																	  @Valid @RequestBody MenuCategoryRegistrationRequest request) {
+		MenuCategoryRegistrationCommand command =
+			new MenuCategoryRegistrationCommand(loginVendor.getId(), storeId, request.name());
+		Long registeredId = menuCategoryRegistrationService.register(command);
+		return new MenuCategoryRegistrationResponse(registeredId);
+	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/store/StoreExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/web/api/store/StoreExceptionHandler.java
@@ -1,10 +1,14 @@
 package camp.woowak.lab.web.api.store;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpStatusCodeException;
 
+import camp.woowak.lab.common.exception.ErrorCode;
+import camp.woowak.lab.common.exception.HttpStatusException;
 import camp.woowak.lab.store.exception.StoreException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,4 +22,13 @@ public class StoreExceptionHandler {
 		return new ResponseEntity<>("fail", HttpStatus.BAD_REQUEST);
 	}
 
+	@ExceptionHandler(HttpStatusCodeException.class)
+	public ProblemDetail handleException(HttpStatusException exception) {
+		log.info(exception.getMessage(), exception);
+		ErrorCode errorCode = exception.errorCode();
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+			HttpStatus.valueOf(errorCode.getStatus()), exception.errorCode().getMessage());
+		problemDetail.setProperty("error_code", errorCode.getErrorCode());
+		return problemDetail;
+	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/store/StoreExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/web/api/store/StoreExceptionHandler.java
@@ -1,14 +1,10 @@
 package camp.woowak.lab.web.api.store;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.HttpStatusCodeException;
 
-import camp.woowak.lab.common.exception.ErrorCode;
-import camp.woowak.lab.common.exception.HttpStatusException;
 import camp.woowak.lab.store.exception.StoreException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,15 +16,5 @@ public class StoreExceptionHandler {
 	public ResponseEntity<?> handleException(StoreException exception) {
 		log.warn(exception.getMessage(), exception);
 		return new ResponseEntity<>("fail", HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(HttpStatusCodeException.class)
-	public ProblemDetail handleException(HttpStatusException exception) {
-		log.info(exception.getMessage(), exception);
-		ErrorCode errorCode = exception.errorCode();
-		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
-			HttpStatus.valueOf(errorCode.getStatus()), exception.errorCode().getMessage());
-		problemDetail.setProperty("error_code", errorCode.getErrorCode());
-		return problemDetail;
 	}
 }

--- a/src/main/java/camp/woowak/lab/web/dto/request/store/MenuCategoryRegistrationRequest.java
+++ b/src/main/java/camp/woowak/lab/web/dto/request/store/MenuCategoryRegistrationRequest.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.web.dto.request.store;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MenuCategoryRegistrationRequest(
+	@NotBlank(message = "메뉴 카테고리 이름은 필수값입니다.")
+	String name
+) {
+}

--- a/src/main/java/camp/woowak/lab/web/dto/request/store/MenuCategoryRegistrationRequest.java
+++ b/src/main/java/camp/woowak/lab/web/dto/request/store/MenuCategoryRegistrationRequest.java
@@ -1,9 +1,11 @@
 package camp.woowak.lab.web.dto.request.store;
 
+import org.hibernate.validator.constraints.Length;
+
 import jakarta.validation.constraints.NotBlank;
 
 public record MenuCategoryRegistrationRequest(
-	@NotBlank(message = "메뉴 카테고리 이름은 필수값입니다.")
+	@NotBlank(message = "메뉴 카테고리 이름은 필수값입니다.") @Length(max = 10)
 	String name
 ) {
 }

--- a/src/main/java/camp/woowak/lab/web/dto/response/store/MenuCategoryRegistrationResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/store/MenuCategoryRegistrationResponse.java
@@ -1,0 +1,6 @@
+package camp.woowak.lab.web.dto.response.store;
+
+public record MenuCategoryRegistrationResponse(
+	Long id
+) {
+}

--- a/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
+++ b/src/main/java/camp/woowak/lab/web/resolver/session/SessionVendorArgumentResolver.java
@@ -32,7 +32,7 @@ public class SessionVendorArgumentResolver extends LoginMemberArgumentResolver {
 		HttpSession session = request.getSession(false);
 		if (parameterAnnotation.required() &&
 			(session == null || session.getAttribute(SessionConst.SESSION_VENDOR_KEY) == null)) {
-			throw new UnauthorizedException(AuthenticationErrorCode.UNAUTHORIZED);
+			throw new UnauthorizedException(AuthenticationErrorCode.UNAUTHORIZED, "Vendor가 세션에 저장되어 있지 않습니다.");
 		}
 		return session == null ? null : session.getAttribute(SessionConst.SESSION_VENDOR_KEY);
 	}

--- a/src/test/java/camp/woowak/lab/fixture/MenuFixture.java
+++ b/src/test/java/camp/woowak/lab/fixture/MenuFixture.java
@@ -1,0 +1,60 @@
+package camp.woowak.lab.fixture;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import camp.woowak.lab.menu.TestMenuCategory;
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.payaccount.domain.TestPayAccount;
+import camp.woowak.lab.store.TestStore;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreAddress;
+import camp.woowak.lab.store.domain.StoreCategory;
+import camp.woowak.lab.vendor.TestVendor;
+import camp.woowak.lab.vendor.domain.Vendor;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import camp.woowak.lab.web.authentication.PasswordEncoder;
+
+public interface MenuFixture {
+	default Vendor createVendor(UUID vendorId) {
+		PayAccount payAccount = new TestPayAccount(1L);
+		PasswordEncoder passwordEncoder = new NoOpPasswordEncoder();
+		return new TestVendor(vendorId, "vendorName", "vendorEmail@example.com", "vendorPassword", "010-0000-0000",
+			payAccount, passwordEncoder);
+	}
+
+	default Store createStore(Vendor owner) {
+		LocalDateTime validStartDateFixture = LocalDateTime.of(2020, 1, 1, 1, 1);
+		LocalDateTime validEndDateFixture = LocalDateTime.of(2020, 1, 1, 2, 1);
+		String validNameFixture = "3K1K 가게";
+		String validAddressFixture = StoreAddress.DEFAULT_DISTRICT;
+		String validPhoneNumberFixture = "02-1234-5678";
+		Integer validMinOrderPriceFixture = 5000;
+
+		return new Store(owner, createStoreCategory(), validNameFixture, validAddressFixture,
+			validPhoneNumberFixture,
+			validMinOrderPriceFixture,
+			validStartDateFixture, validEndDateFixture);
+	}
+
+	default Store createStore(Long id, Vendor owner) {
+		LocalDateTime validStartDateFixture = LocalDateTime.of(2020, 1, 1, 1, 1);
+		LocalDateTime validEndDateFixture = LocalDateTime.of(2020, 1, 1, 2, 1);
+		String validNameFixture = "3K1K 가게";
+		String validAddressFixture = StoreAddress.DEFAULT_DISTRICT;
+		String validPhoneNumberFixture = "02-1234-5678";
+		Integer validMinOrderPriceFixture = 5000;
+
+		return new TestStore(id, owner, createStoreCategory(), validNameFixture, validAddressFixture,
+			validPhoneNumberFixture, validMinOrderPriceFixture, validStartDateFixture, validEndDateFixture);
+	}
+
+	default MenuCategory createMenuCategory(Long id, Store store, String name) {
+		return new TestMenuCategory(id, store, name);
+	}
+
+	default StoreCategory createStoreCategory() {
+		return new StoreCategory("양식");
+	}
+}

--- a/src/test/java/camp/woowak/lab/menu/TestMenuCategory.java
+++ b/src/test/java/camp/woowak/lab/menu/TestMenuCategory.java
@@ -1,0 +1,18 @@
+package camp.woowak.lab.menu;
+
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.store.domain.Store;
+
+public class TestMenuCategory extends MenuCategory {
+	private Long id;
+
+	public TestMenuCategory(Long id, Store store, String name) {
+		super(store, name);
+		this.id = id;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/test/java/camp/woowak/lab/menu/repository/MenuCategoryRepositoryTest.java
+++ b/src/test/java/camp/woowak/lab/menu/repository/MenuCategoryRepositoryTest.java
@@ -3,13 +3,18 @@ package camp.woowak.lab.menu.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import camp.woowak.lab.fixture.MenuFixture;
 import camp.woowak.lab.infra.date.DateTimeProvider;
 import camp.woowak.lab.menu.domain.MenuCategory;
 import camp.woowak.lab.payaccount.domain.PayAccount;
@@ -25,7 +30,7 @@ import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
 
 @DataJpaTest
-class MenuCategoryRepositoryTest {
+class MenuCategoryRepositoryTest implements MenuFixture {
 
 	@Autowired
 	VendorRepository vendorRepository;
@@ -42,69 +47,117 @@ class MenuCategoryRepositoryTest {
 	@Autowired
 	PayAccountRepository payAccountRepository;
 
-	@Nested
-	@DisplayName("가게와 메뉴카테고리 이름으로 메뉴카테고리를 조회하는 기능은")
-	class FindByStoreAndNameTest {
+	@Autowired
+	PasswordEncoder passwordEncoder;
 
-		@Test
-		@DisplayName("[Success] 가게와 메뉴카테고리 이름이 있으면 조회를 성공한다")
-		void success() {
-			// given
-			PayAccount payAccount = payAccountRepository.save(new PayAccount());
-
-			Vendor vendor = createVendor(payAccount);
-			String categoryName = "돈가스";
-			StoreCategory storeCategory = new StoreCategory(categoryName);
-
-			vendorRepository.saveAndFlush(vendor);
-			storeCategoryRepository.saveAndFlush(storeCategory);
-
-			Store store = createStore(vendor, storeCategory);
-			storeRepository.saveAndFlush(store);
-			MenuCategory menuCategory = new MenuCategory(store, categoryName);
-			menuCategoryRepository.save(menuCategory);
-
-			// when & then
-			assertThat(menuCategoryRepository.findByStoreIdAndName(store.getId(), categoryName))
-				.isPresent()
-				.containsSame(menuCategory);
+	@TestConfiguration
+	static class TestContextConfiguration {
+		@Bean
+		public PasswordEncoder passwordEncoder() {
+			return new NoOpPasswordEncoder();
 		}
+	}
 
-		@Test
-		@DisplayName("[Exception] 가게가 없으면 빈 Optional 을 반환한다")
-		void notExistStore() {
-			// given
-			String categoryName = "돈가스";
+	@Test
+	@DisplayName("[Success] 가게와 메뉴카테고리 이름이 있으면 조회를 성공한다")
+	void success() {
+		// given
+		PayAccount payAccount = payAccountRepository.save(new PayAccount());
 
-			// when & then
-			assertThat(menuCategoryRepository.findByStoreIdAndName(1234567L, categoryName)).isEmpty();
-		}
+		Vendor vendor = createVendor(payAccount);
+		String categoryName = "돈가스";
+		StoreCategory storeCategory = new StoreCategory(categoryName);
 
-		@Test
-		@DisplayName("[Exception] 메뉴카테고리 이름이 없으면 빈 Optional 을 반환한다")
-		void notExistMenuCategoryName() {
-			// given
-			String categoryName = "돈가스";
-			String notExistCategoryName = "xxx";
-			PayAccount payAccount = payAccountRepository.save(new PayAccount());
+		vendorRepository.saveAndFlush(vendor);
+		storeCategoryRepository.saveAndFlush(storeCategory);
 
-			Vendor vendor = createVendor(payAccount);
-			vendorRepository.saveAndFlush(vendor);
+		Store store = createStore(vendor, storeCategory);
+		storeRepository.saveAndFlush(store);
+		MenuCategory menuCategory = new MenuCategory(store, categoryName);
+		menuCategoryRepository.save(menuCategory);
 
-			StoreCategory storeCategory = new StoreCategory(categoryName);
-			storeCategoryRepository.saveAndFlush(storeCategory);
+		// when & then
+		assertThat(menuCategoryRepository.findByStoreIdAndName(store.getId(), categoryName))
+			.isPresent()
+			.containsSame(menuCategory);
+	}
 
-			Store store = createStore(vendor, storeCategory);
-			storeRepository.saveAndFlush(store);
+	@Test
+	@DisplayName("[Exception] 가게가 없으면 빈 Optional 을 반환한다")
+	void notExistStore() {
+		// given
+		String categoryName = "돈가스";
 
-			MenuCategory menuCategory = new MenuCategory(store, categoryName);
-			menuCategoryRepository.save(menuCategory);
+		// when & then
+		assertThat(menuCategoryRepository.findByStoreIdAndName(1234567L, categoryName)).isEmpty();
+	}
 
-			// when & then
-			assertThat(menuCategoryRepository.findByStoreIdAndName(store.getId(), notExistCategoryName))
-				.isEmpty();
-		}
+	@Test
+	@DisplayName("[Exception] 메뉴카테고리 이름이 없으면 빈 Optional 을 반환한다")
+	void notExistMenuCategoryName() {
+		// given
+		String categoryName = "돈가스";
+		String notExistCategoryName = "xxx";
+		PayAccount payAccount = payAccountRepository.save(new PayAccount());
 
+		Vendor vendor = createVendor(payAccount);
+		vendorRepository.saveAndFlush(vendor);
+
+		StoreCategory storeCategory = new StoreCategory(categoryName);
+		storeCategoryRepository.saveAndFlush(storeCategory);
+
+		Store store = createStore(vendor, storeCategory);
+		storeRepository.saveAndFlush(store);
+
+		MenuCategory menuCategory = new MenuCategory(store, categoryName);
+		menuCategoryRepository.save(menuCategory);
+
+		// when & then
+		assertThat(menuCategoryRepository.findByStoreIdAndName(store.getId(), notExistCategoryName))
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("[Success] 가게와 이름이 겹치지 않으면 저장된다.")
+	void successSave() {
+		// given
+		PayAccount testPayAccount = payAccountRepository.save(new PayAccount());
+		Vendor testVendor = vendorRepository.save(
+			new Vendor("testVendor", "test@test.com", "testPassword", "010-0000-0000", testPayAccount,
+				passwordEncoder));
+		StoreCategory testStoreCategory = storeCategoryRepository.save(new StoreCategory("중식"));
+		Store testStore = storeRepository.save(createStore(testVendor, testStoreCategory));
+
+		// when
+		MenuCategory menuCategory = new MenuCategory(testStore, "something");
+		MenuCategory savedMenuCategory = menuCategoryRepository.save(menuCategory);
+		Long savedMenuCategoryId = savedMenuCategory.getId();
+		menuCategoryRepository.flush();
+
+		// then
+		Optional<MenuCategory> findMenuCategory = menuCategoryRepository.findById(savedMenuCategoryId);
+		Assertions.assertTrue(findMenuCategory.isPresent());
+		Assertions.assertEquals(findMenuCategory.get().getId(), savedMenuCategoryId);
+	}
+
+	@Test
+	@DisplayName("[Exception] 가게와 이름이 겹치면 예외가 발생한다.")
+	void duplicateStoreAndName() {
+		// given
+		PayAccount testPayAccount = payAccountRepository.save(new PayAccount());
+		Vendor testVendor = vendorRepository.save(
+			new Vendor("testVendor", "test@test.com", "testPassword", "010-0000-0000", testPayAccount,
+				passwordEncoder));
+		StoreCategory testStoreCategory = storeCategoryRepository.save(new StoreCategory("중식"));
+		Store testStore = storeRepository.save(createStore(testVendor, testStoreCategory));
+		menuCategoryRepository.saveAndFlush(new MenuCategory(testStore, "something"));
+
+		// when
+		MenuCategory newMenuCategory = new MenuCategory(testStore, "something");
+
+		// then
+		Assertions.assertThrows(DataIntegrityViolationException.class,
+			() -> menuCategoryRepository.save(newMenuCategory));
 	}
 
 	private Store createStore(Vendor vendor, StoreCategory storeCategory) {

--- a/src/test/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationServiceTest.java
+++ b/src/test/java/camp/woowak/lab/menu/service/MenuCategoryRegistrationServiceTest.java
@@ -1,0 +1,115 @@
+package camp.woowak.lab.menu.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import camp.woowak.lab.fixture.MenuFixture;
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.menu.exception.DuplicateMenuCategoryException;
+import camp.woowak.lab.menu.exception.UnauthorizedMenuCategoryCreationException;
+import camp.woowak.lab.menu.repository.MenuCategoryRepository;
+import camp.woowak.lab.menu.service.command.MenuCategoryRegistrationCommand;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.exception.NotFoundStoreException;
+import camp.woowak.lab.store.repository.StoreRepository;
+import camp.woowak.lab.vendor.exception.DuplicateEmailException;
+
+@ExtendWith(MockitoExtension.class)
+class MenuCategoryRegistrationServiceTest implements MenuFixture {
+	@InjectMocks
+	private MenuCategoryRegistrationService service;
+	@Mock
+	private StoreRepository storeRepository;
+	@Mock
+	private MenuCategoryRepository menuCategoryRepository;
+
+	@Test
+	@DisplayName("[성공] 점주는 새로운 이름의 MenuCategory를 생성할 수 있다.")
+	void success() throws DuplicateEmailException {
+		// given
+		UUID vendorId = UUID.randomUUID();
+		Long storeId = new Random().nextLong();
+		Long menuCategoryId = new Random().nextLong();
+
+		Store store = createStore(storeId, createVendor(vendorId));
+		MenuCategory menuCategory = createMenuCategory(menuCategoryId, store, "싱싱한 회가 왔어요");
+
+		// when
+		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(menuCategoryRepository.saveAndFlush(any(MenuCategory.class))).thenReturn(menuCategory);
+		MenuCategoryRegistrationCommand command = new MenuCategoryRegistrationCommand(vendorId, storeId, "싱싱한 회가 왔어요");
+
+		// then
+		Long registeredId = service.register(command);
+		then(menuCategoryRepository).should().saveAndFlush(any(MenuCategory.class));
+		Assertions.assertEquals(menuCategory.getId(), registeredId);
+	}
+
+	@Test
+	@DisplayName("[예외] 존재하지 않는 Store면 NotFoundStoreException")
+	void failWithNotFoundStore() {
+		// given
+
+		// when
+		when(storeRepository.findById(anyLong())).thenReturn(Optional.empty());
+		MenuCategoryRegistrationCommand command = new MenuCategoryRegistrationCommand(UUID.randomUUID(),
+			new Random().nextLong(), "newCategoryName");
+
+		// then
+		Assertions.assertThrows(NotFoundStoreException.class, () -> service.register(command));
+	}
+
+	@Test
+	@DisplayName("[예외] 점주가 아닌 사용자가 MenuCategory 생성을 시도하면 UnauthorizedMenuCategoryCreationException")
+	void failWithUnauthorized() {
+		// given
+		UUID vendorId = UUID.randomUUID();
+		Long storeId = new Random().nextLong();
+
+		Store store = createStore(storeId, createVendor(vendorId));
+
+		// when
+		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		UUID someUserId = UUID.randomUUID();
+		while (someUserId.equals(vendorId)) {
+			someUserId = UUID.randomUUID();
+		}
+		MenuCategoryRegistrationCommand command = new MenuCategoryRegistrationCommand(someUserId, storeId,
+			"썩은 회가 왔어요");
+
+		// then
+		Assertions.assertThrows(UnauthorizedMenuCategoryCreationException.class, () -> service.register(command));
+	}
+
+	@Test
+	@DisplayName("[예외] 이미 생성되어 있는 메뉴 카테고리와 이름이 동일한 경우 DuplicateMenuCategoryException")
+	void failWithPasswordMismatch() {
+		// given
+		UUID vendorId = UUID.randomUUID();
+		Long storeId = new Random().nextLong();
+
+		Store store = createStore(storeId, createVendor(vendorId));
+
+		// when
+		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(menuCategoryRepository.saveAndFlush(any(MenuCategory.class))).thenThrow(
+			DataIntegrityViolationException.class);
+		MenuCategoryRegistrationCommand command = new MenuCategoryRegistrationCommand(vendorId, storeId, "싱싱한 회가 왔어요");
+
+		// then
+		Assertions.assertThrows(DuplicateMenuCategoryException.class, () -> service.register(command));
+	}
+}

--- a/src/test/java/camp/woowak/lab/store/TestStore.java
+++ b/src/test/java/camp/woowak/lab/store/TestStore.java
@@ -1,0 +1,23 @@
+package camp.woowak.lab.store;
+
+import java.time.LocalDateTime;
+
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreCategory;
+import camp.woowak.lab.vendor.domain.Vendor;
+
+public class TestStore extends Store {
+	private Long id;
+
+	public TestStore(Long id, Vendor owner, StoreCategory storeCategory, String name, String address,
+					 String phoneNumber, Integer minOrderPrice, LocalDateTime startTime, LocalDateTime endTime
+	) {
+		super(owner, storeCategory, name, address, phoneNumber, minOrderPrice, startTime, endTime);
+		this.id = id;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/api/store/StoreApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/store/StoreApiControllerTest.java
@@ -7,11 +7,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,7 +25,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import camp.woowak.lab.common.exception.UnauthorizedException;
 import camp.woowak.lab.infra.date.DateTimeProvider;
+import camp.woowak.lab.menu.exception.UnauthorizedMenuCategoryCreationException;
+import camp.woowak.lab.menu.service.MenuCategoryRegistrationService;
+import camp.woowak.lab.menu.service.command.MenuCategoryRegistrationCommand;
 import camp.woowak.lab.payaccount.domain.PayAccount;
 import camp.woowak.lab.payaccount.domain.TestPayAccount;
 import camp.woowak.lab.store.exception.StoreException;
@@ -31,9 +37,11 @@ import camp.woowak.lab.store.service.StoreRegistrationService;
 import camp.woowak.lab.store.service.dto.StoreRegistrationRequest;
 import camp.woowak.lab.vendor.domain.Vendor;
 import camp.woowak.lab.vendor.repository.VendorRepository;
+import camp.woowak.lab.web.authentication.AuthenticationErrorCode;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
+import camp.woowak.lab.web.dto.request.store.MenuCategoryRegistrationRequest;
 import camp.woowak.lab.web.resolver.session.SessionConst;
 import camp.woowak.lab.web.resolver.session.SessionVendorArgumentResolver;
 
@@ -46,6 +54,9 @@ class StoreApiControllerTest {
 
 	@MockBean
 	private StoreRegistrationService storeRegistrationService;
+
+	@MockBean
+	private MenuCategoryRegistrationService menuCategoryRegistrationService;
 
 	@MockBean
 	private VendorRepository vendorRepository;
@@ -72,67 +83,165 @@ class StoreApiControllerTest {
 		passwordEncoder = new NoOpPasswordEncoder();
 	}
 
-	@Test
-	@DisplayName("[Success] 200 OK")
-	void storeRegistrationSuccess() throws Exception {
-		// given
-		Vendor vendor = createVendor();
-		LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
-		StoreRegistrationRequest request = new StoreRegistrationRequest(
-			"Store Name",
-			"Store Address",
-			"123-456-7890",
-			"Category Name",
-			10000,
-			validStartTimeFixture,
-			validEndTimeFixture
-		);
+	@Nested
+	@DisplayName("점포 생성: POST /stores")
+	class StoreRegistration {
+		@Test
+		@DisplayName("[Success] 200 OK")
+		void storeRegistrationSuccess() throws Exception {
+			// given
+			Vendor vendor = createVendor();
+			LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
+			StoreRegistrationRequest request = new StoreRegistrationRequest(
+				"Store Name",
+				"Store Address",
+				"123-456-7890",
+				"Category Name",
+				10000,
+				validStartTimeFixture,
+				validEndTimeFixture
+			);
 
-		given(sessionVendorArgumentResolver.supportsParameter(any()))
-			.willReturn(true);
-		given(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
-			.willReturn(loginVendor);
-		given(vendorRepository.findById(loginVendor.getId())).willReturn(Optional.of(vendor));
+			given(sessionVendorArgumentResolver.supportsParameter(any()))
+				.willReturn(true);
+			given(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
+				.willReturn(loginVendor);
+			given(vendorRepository.findById(loginVendor.getId())).willReturn(Optional.of(vendor));
 
-		// when & then
-		mockMvc.perform(post("/stores")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
-			.andExpect(status().isOk());
+			// when & then
+			mockMvc.perform(post("/stores")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
+				.andExpect(status().isOk());
 
-		verify(storeRegistrationService).storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+			verify(storeRegistrationService).storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+		}
+
+		@Disabled
+		@Test
+		@DisplayName("[Exception] 400 Bad Request")
+		void storeRegistrationFailure() throws Exception {
+			// given
+			Vendor vendor = createVendor();
+			LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
+			StoreRegistrationRequest request = new StoreRegistrationRequest(
+				"Store Name",
+				"Invalid Category",
+				"Store Address",
+				"123-456-7890",
+				10000,
+				validStartTimeFixture,
+				validEndTimeFixture
+			);
+
+			doThrow(new StoreException(INVALID_STORE_CATEGORY))
+				.when(storeRegistrationService)
+				.storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+
+			// when & then
+			mockMvc.perform(post("/stores")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string("fail"));
+
+			verify(storeRegistrationService).storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+		}
 	}
 
-	@Disabled
-	@Test
-	@DisplayName("[Exception] 400 Bad Request")
-	void storeRegistrationFailure() throws Exception {
-		// given
-		Vendor vendor = createVendor();
-		LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
-		StoreRegistrationRequest request = new StoreRegistrationRequest(
-			"Store Name",
-			"Invalid Category",
-			"Store Address",
-			"123-456-7890",
-			10000,
-			validStartTimeFixture,
-			validEndTimeFixture
-		);
+	@Nested
+	@DisplayName("메뉴 카테고리 생성: POST /stores/{storeId}/category")
+	class StoreCategoryRegistration {
+		@Test
+		@DisplayName("[Success] 200 OK")
+		void success() throws Exception {
+			// given
+			LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
 
-		doThrow(new StoreException(INVALID_STORE_CATEGORY))
-			.when(storeRegistrationService).storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+			// when
+			when(sessionVendorArgumentResolver.supportsParameter(any()))
+				.thenReturn(true);
+			when(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
+				.thenReturn(loginVendor);
+			MenuCategoryRegistrationRequest request = new MenuCategoryRegistrationRequest("아주 싱싱한 회");
 
-		// when & then
-		mockMvc.perform(post("/stores")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
-			.andExpect(status().isBadRequest())
-			.andExpect(content().string("fail"));
+			// then
+			mockMvc.perform(post("/stores/" + new Random().nextLong() + "/category")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
+				.andExpect(status().isOk());
 
-		verify(storeRegistrationService).storeRegistration(any(Vendor.class), any(StoreRegistrationRequest.class));
+			verify(menuCategoryRegistrationService).register(any(MenuCategoryRegistrationCommand.class));
+		}
+
+		@Test
+		@DisplayName("[Exception] 400 Bad Request")
+		void failWith400() throws Exception {
+			// given
+			LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
+
+			// when & then
+			when(sessionVendorArgumentResolver.supportsParameter(any()))
+				.thenReturn(true);
+			when(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
+				.thenReturn(loginVendor);
+			MenuCategoryRegistrationRequest request = new MenuCategoryRegistrationRequest(null);
+
+			// then
+			mockMvc.perform(post("/stores/" + new Random().nextLong() + "/category")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("[Exception] 401 Unauthenticated")
+		void failWith401() throws Exception {
+			// given
+
+			// when
+			when(sessionVendorArgumentResolver.supportsParameter(any()))
+				.thenReturn(false);
+			when(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
+				.thenThrow(
+					new UnauthorizedException(AuthenticationErrorCode.UNAUTHORIZED, "Vendor가 세션에 저장되어 있지 않습니다."));
+			MenuCategoryRegistrationRequest request = new MenuCategoryRegistrationRequest("아주 싱싱한 회");
+
+			// then
+			mockMvc.perform(post("/stores/" + new Random().nextLong() + "/category")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isUnauthorized());
+		}
+
+		@Test
+		@DisplayName("[Exception] 403 Forbidden")
+		void failWith403() throws Exception {
+			// given
+			LoginVendor loginVendor = new LoginVendor(UUID.randomUUID());
+
+			// when
+			when(sessionVendorArgumentResolver.supportsParameter(any()))
+				.thenReturn(true);
+			when(sessionVendorArgumentResolver.resolveArgument(any(), any(), any(), any()))
+				.thenReturn(loginVendor);
+			when(menuCategoryRegistrationService.register(any(MenuCategoryRegistrationCommand.class))).thenThrow(
+				new UnauthorizedMenuCategoryCreationException("권한없는 사용자가 메뉴 카테고리 등록을 시도했습니다."));
+			MenuCategoryRegistrationRequest request = new MenuCategoryRegistrationRequest("아주 싱싱한 회");
+
+			// then
+			mockMvc.perform(post("/stores/" + new Random().nextLong() + "/category")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.sessionAttr(SessionConst.SESSION_VENDOR_KEY, loginVendor))
+				.andExpect(status().isForbidden());
+
+			verify(menuCategoryRegistrationService).register(any(MenuCategoryRegistrationCommand.class));
+		}
 	}
 
 	private Vendor createVendor() {


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #55 

- 점주는 Menu를 등록할 때 어떤 카테고리에 속한 Menu인지 설정해주어야 합니다. 이번 이슈는 (Menu 등록하기 전에) `MenuCategory`를 만들기 위한 기능입니다.
- "등록되어 있는" Store에 생성할 수 있습니다.
- Store의 점주만 등록할 수 있습니다. 이외의 사용자는 생성할 수 없습니다.
- 이미 생성되어 있는 이름으로는 만들 수 없습니다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- Store.isOwnedBy(UUID ownerId); 해당 Vendor의 Store가 맞는지 확인

<br>


## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
