### PR TITLE
[feat] 음식 상품 수량 등록

### DIFF
--- a/src/main/java/camp/woowak/lab/menu/domain/Menu.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/Menu.java
@@ -37,19 +37,25 @@ public class Menu {
 	private Integer price;
 
 	@Column(nullable = false)
+	private Long stockCount;
+
+	@Column(nullable = false)
 	private String imageUrl;
 
-	public Menu(Store store, MenuCategory menuCategory, String name, Integer price, String imageUrl) {
-		MenuValidator.validate(store, menuCategory, name, price, imageUrl);
+	public Menu(Store store, MenuCategory menuCategory, String name,
+				Integer price, Long stockCount, String imageUrl
+	) {
+		MenuValidator.validate(store, menuCategory, name, price, stockCount, imageUrl);
 		this.store = store;
 		this.menuCategory = menuCategory;
 		this.name = name;
 		this.price = price;
+		this.stockCount = stockCount;
 		this.imageUrl = imageUrl;
 	}
 
 	public Long getId() {
 		return id;
 	}
-	
+
 }

--- a/src/main/java/camp/woowak/lab/menu/domain/MenuValidator.java
+++ b/src/main/java/camp/woowak/lab/menu/domain/MenuValidator.java
@@ -10,10 +10,11 @@ public class MenuValidator {
 	private static final int MAX_NAME_LENGTH = 10;
 
 	public static void validate(final Store store, final MenuCategory menuCategory, final String name,
-								final Integer price, final String imageUrl) {
-		validateNotNull(store, menuCategory, name, price, imageUrl);
+								final Integer price, final Long stockCount, final String imageUrl) {
+		validateNotNull(store, menuCategory, name, price, stockCount, imageUrl);
 		validateNotBlank(name, imageUrl);
 		validateNameLength(name);
+		validateStockCount(stockCount);
 		validatePriceNegative(price);
 	}
 
@@ -41,7 +42,13 @@ public class MenuValidator {
 
 	private static void validatePriceNegative(final Integer price) {
 		if (price <= 0) {
-			throw new InvalidMenuCreationException(INVALID_PRICE, "메뉴의 가격은 양수만 가능합니다");
+			throw new InvalidMenuCreationException(INVALID_PRICE, "메뉴의 가격은 양수만 가능합니다. cur: " + price);
+		}
+	}
+
+	private static void validateStockCount(final Long stockCount) {
+		if (stockCount <= 0) {
+			throw new InvalidMenuCreationException(INVALID_STOCK_COUNT, "메뉴의 재고수는 1개 이상 가능합니다. cur: " + stockCount);
 		}
 	}
 

--- a/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
+++ b/src/main/java/camp/woowak/lab/menu/exception/MenuErrorCode.java
@@ -9,11 +9,12 @@ public enum MenuErrorCode implements ErrorCode {
 	DUPLICATE_MENU_CATEGORY(HttpStatus.BAD_REQUEST, "m_1", "이미 생성된 카테고리입니다."),
 	UNAUTHORIZED_MENU_CATEGORY_CREATION(HttpStatus.FORBIDDEN, "m_2", "점주만 카테고리를 생성할 수 있습니다."),
 
-	NULL_EXIST(HttpStatus.BAD_REQUEST, "M0", "값이 존재해야 합니다."),
-	BLANK_EXIST(HttpStatus.BAD_REQUEST, "M1", "빈 문자열이거나 공백 문자열이 포함되면 안됩니다."),
-	INVALID_NAME_RANGE(HttpStatus.BAD_REQUEST, "M2", "이름의 길이 범위를 벗어났습니다."),
+	NULL_EXIST(HttpStatus.BAD_REQUEST, "m_3", "값이 존재해야 합니다."),
+	BLANK_EXIST(HttpStatus.BAD_REQUEST, "m_4", "빈 문자열이거나 공백 문자열이 포함되면 안됩니다."),
+	INVALID_NAME_RANGE(HttpStatus.BAD_REQUEST, "m_5", "이름의 길이 범위를 벗어났습니다."),
 
-	INVALID_PRICE(HttpStatus.BAD_REQUEST, "M3", "메뉴의 가격 범위를 벗어났습니다."),
+	INVALID_PRICE(HttpStatus.BAD_REQUEST, "m_6", "메뉴의 가격 범위를 벗어났습니다."),
+	INVALID_STOCK_COUNT(HttpStatus.BAD_REQUEST, "m_7", "메뉴의 재고 개수는 1개 이상이어야 합니다."),
 
 	NOT_FOUND_MENU_CATEGORY(HttpStatus.BAD_REQUEST, "M3", "메뉴 카테고리를 찾을 수 없습니다.");
 

--- a/src/main/java/camp/woowak/lab/store/service/StoreMenuRegistrationService.java
+++ b/src/main/java/camp/woowak/lab/store/service/StoreMenuRegistrationService.java
@@ -83,7 +83,8 @@ public class StoreMenuRegistrationService {
 
 	private Menu createMenu(final Store store, final MenuLineItem menuLineItem) {
 		MenuCategory menuCategory = findMenuCategoryBy(store, menuLineItem.categoryName());
-		return new Menu(store, menuCategory, menuLineItem.name(), menuLineItem.price(), menuLineItem.imageUrl());
+		return new Menu(store, menuCategory, menuLineItem.name(), menuLineItem.price(),
+			menuLineItem.stockCount(), menuLineItem.imageUrl());
 	}
 
 	private MenuCategory findMenuCategoryBy(final Store store, final String manuCategoryName) {

--- a/src/main/java/camp/woowak/lab/store/service/command/MenuLineItem.java
+++ b/src/main/java/camp/woowak/lab/store/service/command/MenuLineItem.java
@@ -4,16 +4,20 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record MenuLineItem(
-	@NotBlank(message = "메뉴 이름은 필수값입니다.")
+	@NotBlank(message = "음식 상품 이름은 필수값입니다.")
 	String name,
 
-	@NotBlank(message = "사진은 필수값입니다.")
+	@NotNull(message = "음식 상품의 재고수는 필수값입니다.")
+	Long stockCount,
+
+	@NotBlank(message = "음식 상품의 사진은 필수값입니다.")
 	String imageUrl,
 
-	@NotBlank(message = "메뉴 카테고리 이름은 필수값입니다.")
+	@NotBlank(message = "음식 상품 카테고리 이름은 필수값입니다.")
 	String categoryName,
 
-	@NotNull(message = "메뉴 가격은 필수값입니다.")
+	@NotNull(message = "음식 상품 가격은 필수값입니다.")
 	Integer price
+
 ) {
 }

--- a/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
+++ b/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
@@ -147,7 +147,7 @@ class CartServiceTest {
 	private Menu createMenu(Store store, String name, int price) {
 		MenuCategory menuCategory = new MenuCategory(store, "카테고리1");
 		menuCategoryRepository.saveAndFlush(menuCategory);
-		Menu menu1 = new Menu(store, menuCategory,name, price,"imageUrl");
+		Menu menu1 = new Menu(store, menuCategory, name, price, 50L, "imageUrl");
 		menuRepository.saveAndFlush(menu1);
 
 		return menu1;

--- a/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
+++ b/src/test/java/camp/woowak/lab/cart/service/CartServiceTest.java
@@ -202,7 +202,7 @@ class CartServiceTest {
 	}
 
 	private Menu createMenu(Store store, MenuCategory menuCategory, String name, int price) {
-		Menu menu1 = new Menu(store, menuCategory, name, price, "imageUrl");
+		Menu menu1 = new Menu(store, menuCategory, name, price, 1L, "imageUrl");
 		menuRepository.saveAndFlush(menu1);
 
 		return menu1;

--- a/src/test/java/camp/woowak/lab/menu/TestMenu.java
+++ b/src/test/java/camp/woowak/lab/menu/TestMenu.java
@@ -9,7 +9,7 @@ public class TestMenu extends Menu {
 
 	public TestMenu(Long id, Store store, MenuCategory menuCategory,
 					String name, Integer price) {
-		super(store, menuCategory, name, price, "imageUrl");
+		super(store, menuCategory, name, price, 50L, "imageUrl");
 		this.id = id;
 	}
 

--- a/src/test/java/camp/woowak/lab/menu/domain/MenuTest.java
+++ b/src/test/java/camp/woowak/lab/menu/domain/MenuTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import camp.woowak.lab.common.exception.ErrorCode;
 import camp.woowak.lab.menu.exception.InvalidMenuCreationException;
+import camp.woowak.lab.menu.exception.MenuErrorCode;
 import camp.woowak.lab.payaccount.domain.PayAccount;
 import camp.woowak.lab.payaccount.domain.TestPayAccount;
 import camp.woowak.lab.store.domain.Store;
@@ -34,9 +36,15 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(null, menuCategoryFixture, "1234", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(null, menuCategoryFixture, "1234", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 		}
@@ -48,9 +56,15 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, null, "1234", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, null, "1234", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 		}
@@ -70,33 +84,57 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 빈 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isEmpty() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.BLANK_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 공백 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isBlank() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.BLANK_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 10 글자를 초과하면 InvalidMenuCreationException 이 발생한다")
 			void greaterThanMaxNameLength() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "12345678901", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.INVALID_NAME_RANGE;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "12345678901", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 		}
@@ -116,25 +154,43 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", null, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", null, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 음수면 InvalidMenuCreationException 이 발생한다")
 			void isNegative() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", -1, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.INVALID_PRICE;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", -1, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 0이면 InvalidMenuCreationException 이 발생한다")
 			void isZero() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 0, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.INVALID_PRICE;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 0, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 		}
@@ -146,25 +202,43 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 빈 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isEmpty() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.BLANK_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 공백 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isBlank() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.BLANK_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 		}
@@ -175,28 +249,52 @@ class MenuTest {
 			@Test
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, null, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.NULL_EXIST;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, null, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 음수면 InvalidMenuCreationException 이 발생한다")
 			void isEmpty() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, -1L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.INVALID_STOCK_COUNT;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, -1L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 
 			@Test
 			@DisplayName("[Exception] 0개면 InvalidMenuCreationException 이 발생한다")
 			void isBlank() {
-				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, 0L, "image"))
-					.isInstanceOf(InvalidMenuCreationException.class);
+				// given
+				ErrorCode expected = MenuErrorCode.INVALID_STOCK_COUNT;
+
+				// when
+				Throwable thrown = catchThrowable(
+					() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, 0L, "image"));
+
+				// then
+				assertExceptionAndErrorCode(thrown, expected);
 			}
 		}
 
+	}
+
+	private void assertExceptionAndErrorCode(Throwable thrown, ErrorCode expected) {
+		assertThat(thrown).isInstanceOf(InvalidMenuCreationException.class);
+		InvalidMenuCreationException exception = (InvalidMenuCreationException)thrown;
+		assertThat(exception.errorCode()).isEqualTo(expected);
 	}
 
 	private Store createValidStore() {

--- a/src/test/java/camp/woowak/lab/menu/domain/MenuTest.java
+++ b/src/test/java/camp/woowak/lab/menu/domain/MenuTest.java
@@ -35,7 +35,7 @@ class MenuTest {
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
 				// given & when & then
-				assertThatCode(() -> new Menu(null, menuCategoryFixture, "1234", 1000, "image"))
+				assertThatCode(() -> new Menu(null, menuCategoryFixture, "1234", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -49,7 +49,7 @@ class MenuTest {
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, null, "1234", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, null, "1234", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -63,7 +63,7 @@ class MenuTest {
 			@DisplayName("[Success] 10글자 이하만 가능하다")
 			void success() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "1234567890", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "1234567890", 1000, 50L, "image"))
 					.doesNotThrowAnyException();
 			}
 
@@ -71,7 +71,7 @@ class MenuTest {
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -79,7 +79,7 @@ class MenuTest {
 			@DisplayName("[Exception] 빈 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isEmpty() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -87,7 +87,7 @@ class MenuTest {
 			@DisplayName("[Exception] 공백 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isBlank() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -95,7 +95,7 @@ class MenuTest {
 			@DisplayName("[Exception] 10 글자를 초과하면 InvalidMenuCreationException 이 발생한다")
 			void greaterThanMaxNameLength() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "12345678901", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "12345678901", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -109,7 +109,7 @@ class MenuTest {
 			@DisplayName("[Success] 양수만 가능하다")
 			void success() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "1234567890", 1, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "1234567890", 1, 50L, "image"))
 					.doesNotThrowAnyException();
 			}
 
@@ -117,7 +117,7 @@ class MenuTest {
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", null, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", null, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -125,7 +125,7 @@ class MenuTest {
 			@DisplayName("[Exception] 음수면 InvalidMenuCreationException 이 발생한다")
 			void isNegative() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", -1, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", -1, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -133,7 +133,7 @@ class MenuTest {
 			@DisplayName("[Exception] 0이면 InvalidMenuCreationException 이 발생한다")
 			void isZero() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 0, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 0, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -147,7 +147,7 @@ class MenuTest {
 			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
 			void isNull() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, null, 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -155,7 +155,7 @@ class MenuTest {
 			@DisplayName("[Exception] 빈 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isEmpty() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
@@ -163,10 +163,38 @@ class MenuTest {
 			@DisplayName("[Exception] 공백 문자열이면 InvalidMenuCreationException 이 발생한다")
 			void isBlank() {
 				// given & when & then
-				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, "image"))
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "   ", 1000, 50L, "image"))
 					.isInstanceOf(InvalidMenuCreationException.class);
 			}
 
+		}
+
+		@Nested
+		@DisplayName("음식 상품 재고 개수가")
+		class StockCount {
+			@Test
+			@DisplayName("[Exception] Null 이면 InvalidMenuCreationException 이 발생한다")
+			void isNull() {
+				// given & when & then
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, null, "image"))
+					.isInstanceOf(InvalidMenuCreationException.class);
+			}
+
+			@Test
+			@DisplayName("[Exception] 음수면 InvalidMenuCreationException 이 발생한다")
+			void isEmpty() {
+				// given & when & then
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, -1L, "image"))
+					.isInstanceOf(InvalidMenuCreationException.class);
+			}
+
+			@Test
+			@DisplayName("[Exception] 0개면 InvalidMenuCreationException 이 발생한다")
+			void isBlank() {
+				// given & when & then
+				assertThatCode(() -> new Menu(storeFixture, menuCategoryFixture, "메뉴이름", 1000, 0L, "image"))
+					.isInstanceOf(InvalidMenuCreationException.class);
+			}
 		}
 
 	}

--- a/src/test/java/camp/woowak/lab/store/service/StoreMenuRegistrationServiceTest.java
+++ b/src/test/java/camp/woowak/lab/store/service/StoreMenuRegistrationServiceTest.java
@@ -62,7 +62,7 @@ class StoreMenuRegistrationServiceTest {
 		Long storeId = 1L;
 		UUID vendorId = UUID.randomUUID();
 		List<MenuLineItem> menuItems = List.of(
-			new MenuLineItem("메뉴1", "image1.jpg", "카테고리1", 10000)
+			new MenuLineItem("메뉴1", 50L, "image1.jpg", "카테고리1", 10000)
 		);
 
 		StoreMenuRegistrationCommand request = new StoreMenuRegistrationCommand(vendorId, storeId, menuItems);
@@ -88,7 +88,7 @@ class StoreMenuRegistrationServiceTest {
 		Long storeId = 1L;
 		UUID vendorId = UUID.randomUUID();
 		List<MenuLineItem> menuItems = List.of(
-			new MenuLineItem("메뉴1", "image1.jpg", "카테고리1", 10000)
+			new MenuLineItem("메뉴1", 50L, "image1.jpg", "카테고리1", 10000)
 		);
 		StoreMenuRegistrationCommand command = new StoreMenuRegistrationCommand(vendorId, storeId, menuItems);
 

--- a/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
@@ -242,7 +242,7 @@ class CartApiControllerTest {
 	}
 
 	private Menu createMenu(Store store, MenuCategory menuCategory, String name, int price) {
-		Menu menu1 = new Menu(store, menuCategory, name, price, "imageUrl");
+		Menu menu1 = new Menu(store, menuCategory, name, price, 1L, "imageUrl");
 		menuRepository.saveAndFlush(menu1);
 
 		return menu1;

--- a/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/cart/CartApiControllerTest.java
@@ -176,10 +176,10 @@ class CartApiControllerTest {
 	private Menu createMenu(Store store, String name, int price) {
 		MenuCategory menuCategory = new MenuCategory(store, "카테고리1");
 		menuCategoryRepository.saveAndFlush(menuCategory);
-		Menu menu1 = new Menu(store, menuCategory,name, price,"imageUrl");
-		menuRepository.saveAndFlush(menu1);
+		Menu menu = new Menu(store, menuCategory, name, price, 50L, "imageUrl");
+		menuRepository.saveAndFlush(menu);
 
-		return menu1;
+		return menu;
 	}
 
 	private Store createStore(Vendor vendor, String name, int minOrderPrice, LocalDateTime startTime,


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #59 
- 비즈니스 요구사항을 최소화하기 위해, 음식 상품 수량은 점주가 음식 상품을 등록할 때 **함께 등록**합니다.
- 따라서 별도의 API는 생성하지 않았으며, 음식 상품(Menu)의 인스턴스 필드와 생성자에 재고수(stockCount)를 추가하였습니다.

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
