### PR TITLE
[feat] 할인 쿠폰 발급

### DIFF
--- a/src/main/java/camp/woowak/lab/coupon/domain/Coupon.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/Coupon.java
@@ -47,4 +47,8 @@ public class Coupon {
 		this.quantity = quantity;
 		this.expiredAt = expiredAt;
 	}
+
+	public boolean isExpired() {
+		return expiredAt.isBefore(LocalDateTime.now());
+	}
 }

--- a/src/main/java/camp/woowak/lab/coupon/domain/Coupon.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/Coupon.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import camp.woowak.lab.coupon.exception.InsufficientCouponQuantityException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -50,5 +51,16 @@ public class Coupon {
 
 	public boolean isExpired() {
 		return expiredAt.isBefore(LocalDateTime.now());
+	}
+
+	public boolean hasAvailableQuantity() {
+		return quantity > 0;
+	}
+
+	public void decreaseQuantity() {
+		if (!hasAvailableQuantity()) {
+			throw new InsufficientCouponQuantityException("quantity is not enough");
+		}
+		quantity--;
 	}
 }

--- a/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
@@ -30,7 +30,7 @@ public class CouponIssuance {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Customer customer;
 
-	@Column(nullable = false)
+	@Column(nullable = false, updatable = false)
 	@CreatedDate
 	private LocalDateTime issuedAt;
 

--- a/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
@@ -1,0 +1,49 @@
+package camp.woowak.lab.coupon.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import camp.woowak.lab.customer.domain.Customer;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class CouponIssuance {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "coupon_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Coupon coupon;
+
+	@JoinColumn(name = "customer_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Customer customer;
+
+	@Column(nullable = false)
+	@CreatedDate
+	private LocalDateTime issuedAt;
+
+	@Column
+	private LocalDateTime usedAt;
+
+	protected CouponIssuance() {
+	}
+
+	public CouponIssuance(Coupon coupon, Customer customer) {
+
+		this.coupon = coupon;
+		this.customer = customer;
+		this.issuedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
@@ -41,7 +41,7 @@ public class CouponIssuance {
 	}
 
 	public CouponIssuance(Coupon coupon, Customer customer) {
-
+		CouponIssuanceValidator.validate(customer, coupon);
 		this.coupon = coupon;
 		this.customer = customer;
 		this.issuedAt = LocalDateTime.now();

--- a/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuance.java
@@ -42,6 +42,8 @@ public class CouponIssuance {
 
 	public CouponIssuance(Coupon coupon, Customer customer) {
 		CouponIssuanceValidator.validate(customer, coupon);
+		// coupon 수량 감소
+		coupon.decreaseQuantity();
 		this.coupon = coupon;
 		this.customer = customer;
 		this.issuedAt = LocalDateTime.now();

--- a/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuanceValidator.java
+++ b/src/main/java/camp/woowak/lab/coupon/domain/CouponIssuanceValidator.java
@@ -1,0 +1,30 @@
+package camp.woowak.lab.coupon.domain;
+
+import camp.woowak.lab.coupon.exception.ExpiredCouponException;
+import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
+import camp.woowak.lab.customer.domain.Customer;
+
+public class CouponIssuanceValidator {
+	private CouponIssuanceValidator() {
+	}
+
+	public static void validate(Customer customer, Coupon coupon) {
+		validateNotNull(customer, coupon);
+		validateNotExpired(coupon);
+
+	}
+
+	private static void validateNotExpired(Coupon coupon) {
+		if (coupon.isExpired()) {
+			throw new ExpiredCouponException("만료된 쿠폰입니다.");
+		}
+	}
+
+	private static void validateNotNull(Object... objects) {
+		for (var object : objects) {
+			if (object == null) {
+				throw new InvalidICreationIssuanceException("쿠폰 발급에 필요한 정보가 없습니다.");
+			}
+		}
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
@@ -7,6 +7,7 @@ import camp.woowak.lab.common.exception.ErrorCode;
 public enum CouponErrorCode implements ErrorCode {
 	INVALID_CREATION(HttpStatus.BAD_REQUEST, "cp_1_1", "잘못된 요청입니다."),
 	DUPLICATE_COUPON_TITLE(HttpStatus.CONFLICT, "cp_1_2", "중복된 쿠폰 제목입니다."),
+	INSUFFICIENT_QUANTITY(HttpStatus.CONFLICT, "cp_1_3", "발급 가능한 쿠폰이 부족합니다."),
 	;
 
 	int status;

--- a/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
@@ -7,6 +7,7 @@ import camp.woowak.lab.common.exception.ErrorCode;
 public enum CouponErrorCode implements ErrorCode {
 	INVALID_CREATION(HttpStatus.BAD_REQUEST, "cp_1_1", "잘못된 요청입니다."),
 	DUPLICATE_COUPON_TITLE(HttpStatus.CONFLICT, "cp_1_2", "중복된 쿠폰 제목입니다."),
+	EXPIRED_COUPON(HttpStatus.CONFLICT, "cp_1_3", "만료된 쿠폰입니다."),
 	;
 
 	int status;

--- a/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/CouponErrorCode.java
@@ -7,7 +7,6 @@ import camp.woowak.lab.common.exception.ErrorCode;
 public enum CouponErrorCode implements ErrorCode {
 	INVALID_CREATION(HttpStatus.BAD_REQUEST, "cp_1_1", "잘못된 요청입니다."),
 	DUPLICATE_COUPON_TITLE(HttpStatus.CONFLICT, "cp_1_2", "중복된 쿠폰 제목입니다."),
-	EXPIRED_COUPON(HttpStatus.CONFLICT, "cp_1_3", "만료된 쿠폰입니다."),
 	;
 
 	int status;

--- a/src/main/java/camp/woowak/lab/coupon/exception/CouponIssuanceErrorCode.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/CouponIssuanceErrorCode.java
@@ -5,10 +5,10 @@ import org.springframework.http.HttpStatus;
 import camp.woowak.lab.common.exception.ErrorCode;
 
 public enum CouponIssuanceErrorCode implements ErrorCode {
-	INVALID_ISSUANCE(HttpStatus.BAD_REQUEST, "cp_2_1", "잘못된 발급 요청입니다."),
-	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "cp_2_2", "존재하지 않는 쿠폰입니다."),
-	EXPIRED_COUPON(HttpStatus.CONFLICT, "cp_2_3", "만료된 쿠폰입니다."),
-	NOT_ENOUGH_COUPON(HttpStatus.CONFLICT, "cp_2_4", "쿠폰이 부족합니다."),
+	INVALID_ISSUANCE(HttpStatus.BAD_REQUEST, "ci_1_1", "잘못된 발급 요청입니다."),
+	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "ci_1_2", "존재하지 않는 쿠폰입니다."),
+	EXPIRED_COUPON(HttpStatus.CONFLICT, "ci_1_3", "만료된 쿠폰입니다."),
+	NOT_ENOUGH_COUPON(HttpStatus.CONFLICT, "ci_1_4", "쿠폰이 부족합니다."),
 	;
 
 	int status;

--- a/src/main/java/camp/woowak/lab/coupon/exception/CouponIssuanceErrorCode.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/CouponIssuanceErrorCode.java
@@ -1,0 +1,38 @@
+package camp.woowak.lab.coupon.exception;
+
+import org.springframework.http.HttpStatus;
+
+import camp.woowak.lab.common.exception.ErrorCode;
+
+public enum CouponIssuanceErrorCode implements ErrorCode {
+	INVALID_ISSUANCE(HttpStatus.BAD_REQUEST, "cp_2_1", "잘못된 발급 요청입니다."),
+	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "cp_2_2", "존재하지 않는 쿠폰입니다."),
+	EXPIRED_COUPON(HttpStatus.CONFLICT, "cp_2_3", "만료된 쿠폰입니다."),
+	NOT_ENOUGH_COUPON(HttpStatus.CONFLICT, "cp_2_4", "쿠폰이 부족합니다."),
+	;
+
+	int status;
+	String errorCode;
+	String message;
+
+	CouponIssuanceErrorCode(HttpStatus status, String errorCode, String message) {
+		this.status = status.value();
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/exception/DuplicateCouponTitleException.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/DuplicateCouponTitleException.java
@@ -1,8 +1,8 @@
 package camp.woowak.lab.coupon.exception;
 
-import camp.woowak.lab.common.exception.BadRequestException;
+import camp.woowak.lab.common.exception.ConflictException;
 
-public class DuplicateCouponTitleException extends BadRequestException {
+public class DuplicateCouponTitleException extends ConflictException {
 	public DuplicateCouponTitleException(String message) {
 		super(CouponErrorCode.DUPLICATE_COUPON_TITLE, message);
 	}

--- a/src/main/java/camp/woowak/lab/coupon/exception/ExpiredCouponException.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/ExpiredCouponException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.coupon.exception;
+
+import camp.woowak.lab.common.exception.ConflictException;
+
+public class ExpiredCouponException extends ConflictException {
+	public ExpiredCouponException(String message) {
+		super(CouponErrorCode.EXPIRED_COUPON, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/exception/ExpiredCouponException.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/ExpiredCouponException.java
@@ -4,6 +4,6 @@ import camp.woowak.lab.common.exception.ConflictException;
 
 public class ExpiredCouponException extends ConflictException {
 	public ExpiredCouponException(String message) {
-		super(CouponErrorCode.EXPIRED_COUPON, message);
+		super(CouponIssuanceErrorCode.EXPIRED_COUPON, message);
 	}
 }

--- a/src/main/java/camp/woowak/lab/coupon/exception/InsufficientCouponQuantityException.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/InsufficientCouponQuantityException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.coupon.exception;
+
+import camp.woowak.lab.common.exception.ConflictException;
+
+public class InsufficientCouponQuantityException extends ConflictException {
+	public InsufficientCouponQuantityException(String message) {
+		super(CouponErrorCode.INSUFFICIENT_QUANTITY, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/exception/InvalidICreationIssuanceException.java
+++ b/src/main/java/camp/woowak/lab/coupon/exception/InvalidICreationIssuanceException.java
@@ -1,0 +1,9 @@
+package camp.woowak.lab.coupon.exception;
+
+import camp.woowak.lab.common.exception.BadRequestException;
+
+public class InvalidICreationIssuanceException extends BadRequestException {
+	public InvalidICreationIssuanceException(String message) {
+		super(CouponIssuanceErrorCode.INVALID_ISSUANCE, message);
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/repository/CouponIssuanceRepository.java
+++ b/src/main/java/camp/woowak/lab/coupon/repository/CouponIssuanceRepository.java
@@ -1,0 +1,8 @@
+package camp.woowak.lab.coupon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import camp.woowak.lab.coupon.domain.CouponIssuance;
+
+public interface CouponIssuanceRepository extends JpaRepository<CouponIssuance, Long> {
+}

--- a/src/main/java/camp/woowak/lab/coupon/repository/CouponRepository.java
+++ b/src/main/java/camp/woowak/lab/coupon/repository/CouponRepository.java
@@ -1,8 +1,16 @@
 package camp.woowak.lab.coupon.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import camp.woowak.lab.coupon.domain.Coupon;
+import jakarta.persistence.LockModeType;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT c FROM Coupon c WHERE c.id = :id")
+	Optional<Coupon> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -40,7 +40,7 @@ public class IssueCouponService {
 			.orElseThrow(() -> new InvalidICreationIssuanceException("customer not found"));
 
 		// coupon 조회
-		Coupon targetCoupon = couponRepository.findById(cmd.couponId())
+		Coupon targetCoupon = couponRepository.findByIdWithPessimisticLock(cmd.couponId())
 			.orElseThrow(() -> new InvalidICreationIssuanceException("coupon not found"));
 
 		// coupon 수량 확인

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -1,0 +1,48 @@
+package camp.woowak.lab.coupon.service;
+
+import org.springframework.stereotype.Service;
+
+import camp.woowak.lab.coupon.domain.Coupon;
+import camp.woowak.lab.coupon.domain.CouponIssuance;
+import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
+import camp.woowak.lab.coupon.repository.CouponIssuanceRepository;
+import camp.woowak.lab.coupon.repository.CouponRepository;
+import camp.woowak.lab.coupon.service.command.IssueCouponCommand;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import jakarta.transaction.Transactional;
+
+@Service
+public class IssueCouponService {
+	private final CouponIssuanceRepository couponIssuanceRepository;
+	private final CouponRepository couponRepository;
+	private final CustomerRepository customerRepository;
+
+	public IssueCouponService(CouponIssuanceRepository couponIssuanceRepository, CouponRepository couponRepository,
+							  CustomerRepository customerRepository) {
+		this.couponIssuanceRepository = couponIssuanceRepository;
+		this.couponRepository = couponRepository;
+		this.customerRepository = customerRepository;
+	}
+
+	/**
+	 *
+	 * @throws InvalidICreationIssuanceException customer 또는 coupon이 존재하지 않을 경우 또는 coupon이 만료되었을 경우
+	 */
+	@Transactional
+	public Long issueCoupon(IssueCouponCommand cmd) {
+		// customer 조회
+		Customer targetCustomer = customerRepository.findById(cmd.customerId())
+			.orElseThrow(() -> new InvalidICreationIssuanceException("customer not found"));
+
+		// coupon 조회
+		Coupon targetCoupon = couponRepository.findById(cmd.couponId())
+			.orElseThrow(() -> new InvalidICreationIssuanceException("coupon not found"));
+		
+		// coupon issuance 생성
+		CouponIssuance newCouponIssuance = new CouponIssuance(targetCoupon, targetCustomer);
+
+		// coupon issuance 저장
+		return couponIssuanceRepository.save(newCouponIssuance).getId();
+	}
+}

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -29,7 +29,7 @@ public class IssueCouponService {
 
 	/**
 	 *
-	 * @throws InvalidICreationIssuanceException customer 또는 coupon이 존재하지 않을 경우 또는 coupon이 만료되었을 경우
+	 * @throws InvalidICreationIssuanceException customer 또는 coupon이 존재하지 않을 경우
 	 * @throws ExpiredCouponException coupon이 만료되었을 경우
 	 * @throws InsufficientCouponQuantityException coupon 수량이 부족할 경우
 	 */

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -45,7 +45,7 @@ public class IssueCouponService {
 
 		// coupon 수량 확인
 		if (!targetCoupon.hasAvailableQuantity()) {
-			throw new InsufficientCouponQuantityException("coupon is expired");
+			throw new InsufficientCouponQuantityException("quantity of coupon is insufficient");
 		}
 
 		// coupon issuance 생성

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import camp.woowak.lab.coupon.domain.Coupon;
 import camp.woowak.lab.coupon.domain.CouponIssuance;
 import camp.woowak.lab.coupon.exception.ExpiredCouponException;
+import camp.woowak.lab.coupon.exception.InsufficientCouponQuantityException;
 import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
 import camp.woowak.lab.coupon.repository.CouponIssuanceRepository;
 import camp.woowak.lab.coupon.repository.CouponRepository;
@@ -30,6 +31,7 @@ public class IssueCouponService {
 	 *
 	 * @throws InvalidICreationIssuanceException customer 또는 coupon이 존재하지 않을 경우 또는 coupon이 만료되었을 경우
 	 * @throws ExpiredCouponException coupon이 만료되었을 경우
+	 * @throws InsufficientCouponQuantityException coupon 수량이 부족할 경우
 	 */
 	@Transactional
 	public Long issueCoupon(IssueCouponCommand cmd) {
@@ -40,6 +42,11 @@ public class IssueCouponService {
 		// coupon 조회
 		Coupon targetCoupon = couponRepository.findById(cmd.couponId())
 			.orElseThrow(() -> new InvalidICreationIssuanceException("coupon not found"));
+
+		// coupon 수량 확인
+		if (!targetCoupon.hasAvailableQuantity()) {
+			throw new InsufficientCouponQuantityException("coupon is expired");
+		}
 
 		// coupon issuance 생성
 		CouponIssuance newCouponIssuance = new CouponIssuance(targetCoupon, targetCustomer);

--- a/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/IssueCouponService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import camp.woowak.lab.coupon.domain.Coupon;
 import camp.woowak.lab.coupon.domain.CouponIssuance;
+import camp.woowak.lab.coupon.exception.ExpiredCouponException;
 import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
 import camp.woowak.lab.coupon.repository.CouponIssuanceRepository;
 import camp.woowak.lab.coupon.repository.CouponRepository;
@@ -28,6 +29,7 @@ public class IssueCouponService {
 	/**
 	 *
 	 * @throws InvalidICreationIssuanceException customer 또는 coupon이 존재하지 않을 경우 또는 coupon이 만료되었을 경우
+	 * @throws ExpiredCouponException coupon이 만료되었을 경우
 	 */
 	@Transactional
 	public Long issueCoupon(IssueCouponCommand cmd) {
@@ -38,7 +40,7 @@ public class IssueCouponService {
 		// coupon 조회
 		Coupon targetCoupon = couponRepository.findById(cmd.couponId())
 			.orElseThrow(() -> new InvalidICreationIssuanceException("coupon not found"));
-		
+
 		// coupon issuance 생성
 		CouponIssuance newCouponIssuance = new CouponIssuance(targetCoupon, targetCustomer);
 

--- a/src/main/java/camp/woowak/lab/coupon/service/command/IssueCouponCommand.java
+++ b/src/main/java/camp/woowak/lab/coupon/service/command/IssueCouponCommand.java
@@ -1,0 +1,6 @@
+package camp.woowak.lab.coupon.service.command;
+
+import java.util.UUID;
+
+public record IssueCouponCommand(UUID customerId, Long couponId) {
+}

--- a/src/main/java/camp/woowak/lab/customer/repository/CustomerRepository.java
+++ b/src/main/java/camp/woowak/lab/customer/repository/CustomerRepository.java
@@ -1,11 +1,12 @@
 package camp.woowak.lab.customer.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import camp.woowak.lab.customer.domain.Customer;
 
-public interface CustomerRepository extends JpaRepository<Customer, Long> {
+public interface CustomerRepository extends JpaRepository<Customer, UUID> {
 	Optional<Customer> findByEmail(String email);
 }

--- a/src/main/java/camp/woowak/lab/web/api/coupon/CouponApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/coupon/CouponApiController.java
@@ -1,23 +1,31 @@
 package camp.woowak.lab.web.api.coupon;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import camp.woowak.lab.coupon.service.CreateCouponService;
+import camp.woowak.lab.coupon.service.IssueCouponService;
 import camp.woowak.lab.coupon.service.command.CreateCouponCommand;
+import camp.woowak.lab.coupon.service.command.IssueCouponCommand;
+import camp.woowak.lab.web.authentication.LoginCustomer;
+import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
 import camp.woowak.lab.web.dto.request.coupon.CreateCouponRequest;
 import camp.woowak.lab.web.dto.response.coupon.CreateCouponResponse;
+import camp.woowak.lab.web.dto.response.coupon.IssueCouponResponse;
 import jakarta.validation.Valid;
 
 @RestController
 public class CouponApiController {
 	private final CreateCouponService createCouponService;
+	private final IssueCouponService issueCouponService;
 
-	public CouponApiController(CreateCouponService createCouponService) {
+	public CouponApiController(CreateCouponService createCouponService, IssueCouponService issueCouponService) {
 		this.createCouponService = createCouponService;
+		this.issueCouponService = issueCouponService;
 	}
 
 	@PostMapping("/coupons")
@@ -31,4 +39,14 @@ public class CouponApiController {
 		return new CreateCouponResponse(couponId);
 	}
 
+	@PostMapping("/coupons/{couponId}/issue")
+	@ResponseStatus(HttpStatus.CREATED)
+	public IssueCouponResponse issueCoupon(@AuthenticationPrincipal LoginCustomer loginCustomer,
+										   @PathVariable Long couponId) {
+		IssueCouponCommand cmd = new IssueCouponCommand(loginCustomer.getId(), couponId);
+
+		issueCouponService.issueCoupon(cmd);
+
+		return new IssueCouponResponse();
+	}
 }

--- a/src/main/java/camp/woowak/lab/web/api/coupon/CouponExceptionHandler.java
+++ b/src/main/java/camp/woowak/lab/web/api/coupon/CouponExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import camp.woowak.lab.common.advice.DomainExceptionHandler;
 import camp.woowak.lab.common.exception.HttpStatusException;
 import camp.woowak.lab.coupon.exception.DuplicateCouponTitleException;
+import camp.woowak.lab.coupon.exception.ExpiredCouponException;
+import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -19,6 +21,22 @@ public class CouponExceptionHandler {
 	 */
 	@ExceptionHandler(value = DuplicateCouponTitleException.class)
 	public ProblemDetail handleDuplicateCouponTitleException(DuplicateCouponTitleException e) {
+		log.warn("Conflict", e.getMessage());
+		return getProblemDetail(e, HttpStatus.CONFLICT);
+	}
+
+	/**
+	 *
+	 * InvalidICreationIssuanceException.class 를 처리한다.
+	 */
+	@ExceptionHandler(value = InvalidICreationIssuanceException.class)
+	public ProblemDetail handleInvalidICreationIssuanceException(InvalidICreationIssuanceException e) {
+		log.warn("Bad Request", e.getMessage());
+		return getProblemDetail(e, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = ExpiredCouponException.class)
+	public ProblemDetail handleExpiredCouponException(ExpiredCouponException e) {
 		log.warn("Conflict", e.getMessage());
 		return getProblemDetail(e, HttpStatus.CONFLICT);
 	}

--- a/src/main/java/camp/woowak/lab/web/dto/response/coupon/IssueCouponResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/coupon/IssueCouponResponse.java
@@ -1,0 +1,4 @@
+package camp.woowak.lab.web.dto.response.coupon;
+
+public record IssueCouponResponse() {
+}

--- a/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import camp.woowak.lab.coupon.exception.ExpiredCouponException;
+import camp.woowak.lab.coupon.exception.InvalidICreationIssuanceException;
 import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.fixture.CouponFixture;
 import camp.woowak.lab.fixture.CustomerFixture;
@@ -55,7 +56,7 @@ class CouponIssuanceTest implements CouponFixture, CustomerFixture {
 		Customer customer = createCustomer(createPayAccount(), passwordEncoder);
 
 		// when & then
-		assertThrows(NullPointerException.class, () -> new CouponIssuance(coupon, customer));
+		assertThrows(InvalidICreationIssuanceException.class, () -> new CouponIssuance(coupon, customer));
 	}
 
 	@Test
@@ -66,7 +67,7 @@ class CouponIssuanceTest implements CouponFixture, CustomerFixture {
 		Customer customer = null;
 
 		// when & then
-		assertThrows(NullPointerException.class, () -> new CouponIssuance(coupon, customer));
+		assertThrows(InvalidICreationIssuanceException.class, () -> new CouponIssuance(coupon, customer));
 	}
 
 	@Test

--- a/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import camp.woowak.lab.coupon.exception.CouponExpiredException;
+import camp.woowak.lab.coupon.exception.ExpiredCouponException;
 import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.fixture.CouponFixture;
 import camp.woowak.lab.fixture.CustomerFixture;
@@ -83,6 +83,6 @@ class CouponIssuanceTest implements CouponFixture, CustomerFixture {
 		Customer customer = createCustomer(payAccount, passwordEncoder);
 
 		// when & then
-		assertThrows(CouponExpiredException.class, () -> new CouponIssuance(coupon, customer));
+		assertThrows(ExpiredCouponException.class, () -> new CouponIssuance(coupon, customer));
 	}
 }

--- a/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import camp.woowak.lab.coupon.exception.CouponExpiredException;
 import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.fixture.CouponFixture;
 import camp.woowak.lab.fixture.CustomerFixture;
@@ -44,5 +45,44 @@ class CouponIssuanceTest implements CouponFixture, CustomerFixture {
 		assertEquals(customer, couponIssuance.getCustomer());
 		assertNotNull(couponIssuance.getIssuedAt());
 		assertNull(couponIssuance.getUsedAt());
+	}
+
+	@Test
+	@DisplayName("CouponIssuance 생성 테스트 - 쿠폰이 null 인 경우")
+	void testConstructWithNullCoupon() {
+		// given
+		Coupon coupon = null;
+		Customer customer = createCustomer(createPayAccount(), passwordEncoder);
+
+		// when & then
+		assertThrows(NullPointerException.class, () -> new CouponIssuance(coupon, customer));
+	}
+
+	@Test
+	@DisplayName("CouponIssuance 생성 테스트 - 고객이 null 인 경우")
+	void testConstructWithNullCustomer() {
+		// given
+		Coupon coupon = createCoupon(1L, "할인 쿠폰", 1000, 100, LocalDateTime.now().plusDays(7));
+		Customer customer = null;
+
+		// when & then
+		assertThrows(NullPointerException.class, () -> new CouponIssuance(coupon, customer));
+	}
+
+	@Test
+	@DisplayName("CouponIssuance 생성 테스트 - 쿠폰이 만료되었을 때")
+	void testConstructWithExpiredCoupon() {
+		// given
+		Long fakeCouponId = 1L;
+		String title = "할인 쿠폰";
+		int discountAmount = 1000;
+		int quantity = 100;
+		LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+		PayAccount payAccount = createPayAccount();
+		Coupon coupon = createCoupon(fakeCouponId, title, discountAmount, quantity, expiredAt);
+		Customer customer = createCustomer(payAccount, passwordEncoder);
+
+		// when & then
+		assertThrows(CouponExpiredException.class, () -> new CouponIssuance(coupon, customer));
 	}
 }

--- a/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
@@ -1,0 +1,48 @@
+package camp.woowak.lab.coupon.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.fixture.CouponFixture;
+import camp.woowak.lab.fixture.CustomerFixture;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import camp.woowak.lab.web.authentication.PasswordEncoder;
+
+class CouponIssuanceTest implements CouponFixture, CustomerFixture {
+	private static PasswordEncoder passwordEncoder;
+
+	@BeforeAll
+	static void setUpAll() {
+		passwordEncoder = new NoOpPasswordEncoder();
+	}
+
+	@Test
+	@DisplayName("CouponIssuance 생성 테스트")
+	void testConstruct() {
+		// given
+		Long fakeCouponId = 1L;
+		String title = "할인 쿠폰";
+		int discountAmount = 1000;
+		int quantity = 100;
+		LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+		PayAccount payAccount = createPayAccount();
+		Coupon coupon = createCoupon(fakeCouponId, title, discountAmount, quantity, expiredAt);
+		Customer customer = createCustomer(payAccount, passwordEncoder);
+
+		// when
+		CouponIssuance couponIssuance = new CouponIssuance(coupon, customer);
+
+		// then
+		assertEquals(coupon, couponIssuance.getCoupon());
+		assertEquals(customer, couponIssuance.getCustomer());
+		assertNotNull(couponIssuance.getIssuedAt());
+		assertNull(couponIssuance.getUsedAt());
+	}
+}

--- a/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/CouponIssuanceTest.java
@@ -80,7 +80,9 @@ class CouponIssuanceTest implements CouponFixture, CustomerFixture {
 		int quantity = 100;
 		LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
 		PayAccount payAccount = createPayAccount();
-		Coupon coupon = createCoupon(fakeCouponId, title, discountAmount, quantity, expiredAt);
+		TestCoupon coupon = (TestCoupon)createCoupon(fakeCouponId, title, discountAmount, quantity,
+			LocalDateTime.now().plusDays(7));
+		coupon.setExpiredAt(expiredAt);
 		Customer customer = createCustomer(payAccount, passwordEncoder);
 
 		// when & then

--- a/src/test/java/camp/woowak/lab/coupon/domain/TestCoupon.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/TestCoupon.java
@@ -2,14 +2,18 @@ package camp.woowak.lab.coupon.domain;
 
 import java.time.LocalDateTime;
 
+import camp.woowak.lab.coupon.exception.InsufficientCouponQuantityException;
+
 public class TestCoupon extends Coupon {
 	private final Long id;
+	private int quantity;
 	private LocalDateTime expiredAt;
 
-	public TestCoupon(Long id, String title, int discountAmount, int amount, LocalDateTime expiredAt) {
-		super(title, discountAmount, amount, expiredAt);
+	public TestCoupon(Long id, String title, int discountAmount, int quantity, LocalDateTime expiredAt) {
+		super(title, discountAmount, quantity, expiredAt);
 		this.id = id;
 		this.expiredAt = expiredAt;
+		this.quantity = quantity;
 	}
 
 	@Override
@@ -24,5 +28,22 @@ public class TestCoupon extends Coupon {
 	@Override
 	public boolean isExpired() {
 		return expiredAt.isBefore(LocalDateTime.now());
+	}
+
+	@Override
+	public void decreaseQuantity() {
+		if (!hasAvailableQuantity()) {
+			throw new InsufficientCouponQuantityException("쿠폰의 수량이 부족합니다.");
+		}
+		this.quantity--;
+	}
+
+	@Override
+	public boolean hasAvailableQuantity() {
+		return this.quantity > 0;
+	}
+
+	public void setQuantity(int quantity) {
+		this.quantity = quantity;
 	}
 }

--- a/src/test/java/camp/woowak/lab/coupon/domain/TestCoupon.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/TestCoupon.java
@@ -4,14 +4,25 @@ import java.time.LocalDateTime;
 
 public class TestCoupon extends Coupon {
 	private final Long id;
+	private LocalDateTime expiredAt;
 
 	public TestCoupon(Long id, String title, int discountAmount, int amount, LocalDateTime expiredAt) {
 		super(title, discountAmount, amount, expiredAt);
 		this.id = id;
+		this.expiredAt = expiredAt;
 	}
 
 	@Override
 	public Long getId() {
 		return id;
+	}
+
+	public void setExpiredAt(LocalDateTime expiredAt) {
+		this.expiredAt = expiredAt;
+	}
+
+	@Override
+	public boolean isExpired() {
+		return expiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/test/java/camp/woowak/lab/coupon/domain/TestCouponIssuance.java
+++ b/src/test/java/camp/woowak/lab/coupon/domain/TestCouponIssuance.java
@@ -1,0 +1,17 @@
+package camp.woowak.lab.coupon.domain;
+
+import camp.woowak.lab.customer.domain.Customer;
+
+public class TestCouponIssuance extends CouponIssuance {
+	private final Long id;
+
+	public TestCouponIssuance(Long id, Coupon coupon, Customer customer) {
+		super(coupon, customer);
+		this.id = id;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/test/java/camp/woowak/lab/coupon/service/IssueCouponServiceIntegrationTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/service/IssueCouponServiceIntegrationTest.java
@@ -1,0 +1,157 @@
+package camp.woowak.lab.coupon.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import camp.woowak.lab.coupon.domain.Coupon;
+import camp.woowak.lab.coupon.domain.CouponIssuance;
+import camp.woowak.lab.coupon.exception.InsufficientCouponQuantityException;
+import camp.woowak.lab.coupon.repository.CouponIssuanceRepository;
+import camp.woowak.lab.coupon.repository.CouponRepository;
+import camp.woowak.lab.coupon.service.command.IssueCouponCommand;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import camp.woowak.lab.fixture.CouponFixture;
+import camp.woowak.lab.fixture.CustomerFixture;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.payaccount.repository.PayAccountRepository;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+class IssueCouponServiceIntegrationTest implements CouponFixture, CustomerFixture {
+	@Autowired
+	private IssueCouponService service;
+
+	@Autowired
+	private CouponIssuanceRepository couponIssuanceRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CustomerRepository customerRepository;
+
+	@Autowired
+	private PayAccountRepository payAccountRepository;
+
+	@Test
+	@DisplayName("쿠폰 발급 테스트 - 성공")
+	@Transactional
+	void testIssueCoupon() {
+		// given
+		int initialQuantity = 100;
+		Coupon coupon = createCoupon("할인 쿠폰", 1000, initialQuantity, LocalDateTime.now().plusDays(7));
+		// 쿠폰 등록
+		Long couponId = couponRepository.save(coupon).getId();
+
+		// 고객 등록
+		// 계좌 생성
+		PayAccount payAccount = payAccountRepository.save(createPayAccount());
+		Customer customer = createCustomer(payAccount, new NoOpPasswordEncoder());
+		UUID customerId = customerRepository.saveAndFlush(customer).getId();
+		IssueCouponCommand cmd = new IssueCouponCommand(customerId, couponId);
+
+		// when
+		Long saveCouponIssuanceId = service.issueCoupon(cmd);
+		CouponIssuance couponIssuance = couponIssuanceRepository.findById(saveCouponIssuanceId).get();
+
+		// then
+		// 쿠폰 발급 확인
+		assertNotNull(saveCouponIssuanceId);
+		assertEquals(coupon.getId(), couponIssuance.getCoupon().getId());
+		assertEquals(customer.getId(), couponIssuance.getCustomer().getId());
+		assertEquals(initialQuantity - 1, couponIssuance.getCoupon().getQuantity());
+	}
+
+	@Test
+	@DisplayName("쿠폰 발급 테스트 - 수량 부족 실패")
+	@Transactional
+	void testIssueCouponFailWithInsufficientQuantity() {
+		// given
+		Coupon coupon = createCoupon("할인 쿠폰", 1000, 1, LocalDateTime.now().plusDays(7));
+		coupon.decreaseQuantity();
+		// 쿠폰 등록
+		Long couponId = couponRepository.save(coupon).getId();
+
+		// 고객 등록
+		// 계좌 생성
+		PayAccount payAccount = payAccountRepository.save(createPayAccount());
+		Customer customer = createCustomer(payAccount, new NoOpPasswordEncoder());
+		UUID customerId = customerRepository.saveAndFlush(customer).getId();
+		IssueCouponCommand cmd = new IssueCouponCommand(customerId, couponId);
+
+		// when & then
+		assertThrows(InsufficientCouponQuantityException.class,
+			() -> service.issueCoupon(cmd));
+	}
+
+	@Test
+	@DisplayName("쿠폰 발급 테스트 - 동시성 제어")
+	void testIssueCouponWithConcurrency() throws InterruptedException {
+		// given
+		int couponQuantity = 10;
+		int numberOfThreads = 20;
+		Coupon coupon = createCoupon("할인 쿠폰", 1000, couponQuantity, LocalDateTime.now().plusDays(7));
+		Long couponId = couponRepository.save(coupon).getId();
+
+		PayAccount payAccount = payAccountRepository.save(createPayAccount());
+		Customer customer = createCustomer(payAccount, new NoOpPasswordEncoder());
+		UUID customerId = customerRepository.saveAndFlush(customer).getId();
+
+		IssueCouponCommand cmd = new IssueCouponCommand(customerId, couponId);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+		CountDownLatch latch = new CountDownLatch(numberOfThreads);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failCount = new AtomicInteger(0);
+		List<Exception> exceptions = new ArrayList<>();
+
+		// when
+		for (int i = 0; i < numberOfThreads; i++) {
+			executorService.submit(() -> {
+				try {
+					service.issueCoupon(cmd);
+					successCount.incrementAndGet();
+				} catch (InsufficientCouponQuantityException e) {
+					failCount.incrementAndGet();
+				} catch (Exception e) {
+					exceptions.add(e);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await(); // 모든 스레드가 작업을 마칠 때까지 대기
+		executorService.shutdown();
+
+		// then
+		assertEquals(couponQuantity, successCount.get(), "성공적으로 발급된 쿠폰 수가 초기 수량과 일치해야 합니다.");
+		assertEquals(numberOfThreads - couponQuantity, failCount.get(), "실패한 요청 수가 예상과 일치해야 합니다.");
+		assertTrue(exceptions.isEmpty(), "예상치 못한 예외가 발생하지 않아야 합니다.");
+
+		Coupon updatedCoupon = couponRepository.findById(couponId).orElseThrow();
+		assertEquals(0, updatedCoupon.getQuantity(), "모든 쿠폰이 소진되어야 합니다.");
+
+		// 쓰레드 트랜잭션 전파 문제로 인해 수동 데이터 제거
+		// 데이터 제거
+		couponIssuanceRepository.deleteAll();
+		couponRepository.delete(updatedCoupon);
+		customerRepository.delete(customer);
+		payAccountRepository.delete(payAccount);
+	}
+}

--- a/src/test/java/camp/woowak/lab/coupon/service/IssueCouponServiceTest.java
+++ b/src/test/java/camp/woowak/lab/coupon/service/IssueCouponServiceTest.java
@@ -1,0 +1,67 @@
+package camp.woowak.lab.coupon.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import camp.woowak.lab.coupon.domain.Coupon;
+import camp.woowak.lab.coupon.domain.CouponIssuance;
+import camp.woowak.lab.coupon.repository.CouponIssuanceRepository;
+import camp.woowak.lab.coupon.repository.CouponRepository;
+import camp.woowak.lab.coupon.service.command.IssueCouponCommand;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import camp.woowak.lab.fixture.CouponFixture;
+import camp.woowak.lab.fixture.CouponIssuanceFixture;
+import camp.woowak.lab.fixture.CustomerFixture;
+
+@ExtendWith(MockitoExtension.class)
+class IssueCouponServiceTest implements CouponFixture, CustomerFixture, CouponIssuanceFixture {
+	@InjectMocks
+	private IssueCouponService issueCouponService;
+
+	@Mock
+	private CouponIssuanceRepository couponIssuanceRepository;
+
+	@Mock
+	private CustomerRepository customerRepository;
+
+	@Mock
+	private CouponRepository couponRepository;
+
+	@Test
+	@DisplayName("Coupon 발급 테스트 - 성공")
+	void testIssueCoupon() {
+		// given
+		UUID fakeCustomerId = UUID.randomUUID();
+		Long fakeCouponId = 1L;
+		Long fakeCouponIssuanceId = 1L;
+		Coupon fakeCoupon = createCoupon(fakeCouponId, "할인 쿠폰", 1000, 100, LocalDateTime.now().plusDays(7));
+		Customer fakeCustomer = createCustomer(fakeCustomerId);
+		CouponIssuance fakeCouponIssuance = createCouponIssuance(fakeCouponId, fakeCoupon, fakeCustomer);
+		given(customerRepository.findById(fakeCustomerId)).willReturn(Optional.of(fakeCustomer));
+		given(couponRepository.findById(fakeCouponId)).willReturn(Optional.of(fakeCoupon));
+		given(couponIssuanceRepository.save(any(CouponIssuance.class))).willReturn(fakeCouponIssuance);
+
+		IssueCouponCommand cmd = new IssueCouponCommand(fakeCustomerId, fakeCouponId);
+
+		// when
+		Long saveId = issueCouponService.issueCoupon(cmd);
+
+		// then
+		assertEquals(fakeCouponIssuanceId, saveId);
+		verify(customerRepository).findById(fakeCustomerId);
+		verify(couponRepository).findById(fakeCouponId);
+		verify(couponIssuanceRepository).save(any(CouponIssuance.class));
+	}
+}

--- a/src/test/java/camp/woowak/lab/customer/domain/TestCustomer.java
+++ b/src/test/java/camp/woowak/lab/customer/domain/TestCustomer.java
@@ -1,0 +1,22 @@
+package camp.woowak.lab.customer.domain;
+
+import java.util.UUID;
+
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+
+public class TestCustomer extends Customer {
+	private final UUID id;
+
+	public TestCustomer(UUID id, String customerName, String mail, String customerPassword, String s,
+						PayAccount payAccount,
+						NoOpPasswordEncoder noOpPasswordEncoder) {
+		super(customerName, mail, customerPassword, s, payAccount, noOpPasswordEncoder);
+		this.id = id;
+	}
+
+	@Override
+	public UUID getId() {
+		return id;
+	}
+}

--- a/src/test/java/camp/woowak/lab/fixture/CouponFixture.java
+++ b/src/test/java/camp/woowak/lab/fixture/CouponFixture.java
@@ -9,6 +9,10 @@ import camp.woowak.lab.coupon.domain.TestCoupon;
  * CouponFixture는 테스트에서 사용할 Coupon 객체를 생성하는 역할을 합니다.
  */
 public interface CouponFixture {
+	default Coupon createCoupon(String title, int discountAmount, int quantity, LocalDateTime expiredAt) {
+		return new Coupon(title, discountAmount, quantity, expiredAt);
+	}
+
 	default Coupon createCoupon(Long id, String title, int discountAmount, int quantity, LocalDateTime expiredAt) {
 		return new TestCoupon(id, title, discountAmount, quantity, expiredAt);
 	}

--- a/src/test/java/camp/woowak/lab/fixture/CouponFixture.java
+++ b/src/test/java/camp/woowak/lab/fixture/CouponFixture.java
@@ -9,7 +9,7 @@ import camp.woowak.lab.coupon.domain.TestCoupon;
  * CouponFixture는 테스트에서 사용할 Coupon 객체를 생성하는 역할을 합니다.
  */
 public interface CouponFixture {
-	default Coupon createCoupon(Long id, String title, int discountAmount, int amount, LocalDateTime expiredAt) {
-		return new TestCoupon(id, title, discountAmount, amount, expiredAt);
+	default Coupon createCoupon(Long id, String title, int discountAmount, int quantity, LocalDateTime expiredAt) {
+		return new TestCoupon(id, title, discountAmount, quantity, expiredAt);
 	}
 }

--- a/src/test/java/camp/woowak/lab/fixture/CouponIssuanceFixture.java
+++ b/src/test/java/camp/woowak/lab/fixture/CouponIssuanceFixture.java
@@ -1,0 +1,15 @@
+package camp.woowak.lab.fixture;
+
+import camp.woowak.lab.coupon.domain.Coupon;
+import camp.woowak.lab.coupon.domain.CouponIssuance;
+import camp.woowak.lab.coupon.domain.TestCouponIssuance;
+import camp.woowak.lab.customer.domain.Customer;
+
+/**
+ * CouponIssuanceFixture는 테스트에서 CouponIssuance를 생성할 때 사용하는 Fixture입니다.
+ */
+public interface CouponIssuanceFixture {
+	default CouponIssuance createCouponIssuance(Long id, Coupon coupon, Customer customer) {
+		return new TestCouponIssuance(id, coupon, customer);
+	}
+}

--- a/src/test/java/camp/woowak/lab/fixture/CustomerFixture.java
+++ b/src/test/java/camp/woowak/lab/fixture/CustomerFixture.java
@@ -1,8 +1,12 @@
 package camp.woowak.lab.fixture;
 
+import java.util.UUID;
+
 import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.domain.TestCustomer;
 import camp.woowak.lab.customer.exception.InvalidCreationException;
 import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
 
 /**
@@ -23,4 +27,13 @@ public interface CustomerFixture {
 		}
 	}
 
+	default Customer createCustomer(UUID id) {
+		try {
+			return new TestCustomer(id, "customerName", "customer@email.com", "customerPassword", "010-0000-0000",
+				createPayAccount(),
+				new NoOpPasswordEncoder());
+		} catch (InvalidCreationException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
@@ -27,6 +27,7 @@ import camp.woowak.lab.coupon.service.command.CreateCouponCommand;
 import camp.woowak.lab.coupon.service.command.IssueCouponCommand;
 import camp.woowak.lab.web.authentication.LoginCustomer;
 import camp.woowak.lab.web.dto.request.coupon.CreateCouponRequest;
+import camp.woowak.lab.web.resolver.session.SessionConst;
 
 @WebMvcTest(CouponApiController.class)
 @MockBean(JpaMetamodelMappingContext.class)
@@ -134,7 +135,7 @@ class CouponApiControllerTest {
 		LoginCustomer loginCustomer = new LoginCustomer(customerId);
 
 		MockHttpSession session = new MockHttpSession();
-		session.setAttribute("loginCustomer", loginCustomer);
+		session.setAttribute(SessionConst.SESSION_CUSTOMER_KEY, loginCustomer);
 
 		given(issueCouponService.issueCoupon(any(IssueCouponCommand.class))).willReturn(1L);
 
@@ -144,6 +145,6 @@ class CouponApiControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 			.andDo(print())
-			.andExpect(status().isOk());
+			.andExpect(status().isCreated());
 	}
 }

--- a/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
@@ -36,7 +36,7 @@ class CouponApiControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 성공")
+	@DisplayName("쿠폰 등록 테스트 - 성공")
 	void testCreateCoupon() throws Exception {
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -49,7 +49,7 @@ class CouponApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 잘못된 제목 입력 시 실패")
+	@DisplayName("쿠폰 등록 테스트 - 잘못된 제목 입력 시 실패")
 	void testCreateCouponFailWithInvalidTitle() throws Exception {
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -61,7 +61,7 @@ class CouponApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 잘못된 할인 금액 입력 시 실패")
+	@DisplayName("쿠폰 등록 테스트 - 잘못된 할인 금액 입력 시 실패")
 	void testCreateCouponFailWithInvalidDiscountAmount() throws Exception {
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -73,7 +73,7 @@ class CouponApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 잘못된 수량 입력 시 실패")
+	@DisplayName("쿠폰 등록 테스트 - 잘못된 수량 입력 시 실패")
 	void testCreateCouponFailWithInvalidQuantity() throws Exception {
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -85,7 +85,7 @@ class CouponApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 잘못된 만료일 입력 시 실패")
+	@DisplayName("쿠폰 등록 테스트 - 잘못된 만료일 입력 시 실패")
 	void testCreateCouponFailWithInvalidExpiredAt() throws Exception {
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -97,7 +97,7 @@ class CouponApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰 발급 테스트 - 중복된 제목 입력 시 실패")
+	@DisplayName("쿠폰 등록 테스트 - 중복된 제목 입력 시 실패")
 	void testCreateCouponFailWithDuplicateTitle() throws Exception {
 		// given
 		CreateCouponRequest request = new CreateCouponRequest("테스트 쿠폰", 1000, 100, LocalDateTime.now().plusDays(7));
@@ -113,4 +113,5 @@ class CouponApiControllerTest {
 			.andDo(print())
 			.andExpect(status().isConflict());
 	}
+
 }

--- a/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/coupon/CouponApiControllerTest.java
@@ -38,6 +38,9 @@ class CouponApiControllerTest {
 	@Test
 	@DisplayName("쿠폰 등록 테스트 - 성공")
 	void testCreateCoupon() throws Exception {
+		// given
+		given(createCouponService.createCoupon(any(CreateCouponCommand.class))).willReturn(1L);
+
 		mockMvc.perform(post("/coupons")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #75 

- 할인 쿠폰 발급

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

### CouponIssuance
쿠폰 발급 엔티티 입니다.

### IssueCouponeService
쿠폰 발급 로직을 담당하는 서비스입니다.

<br>

## 💡 이런 고민을 했어요.

###  동시성 제어 성능 고민
- 낙관적 락 사용
![image](https://github.com/user-attachments/assets/2cfe0399-6bd7-4bb7-8d69-f25c531d7005)

- 비관적 락 사용
![image](https://github.com/user-attachments/assets/9f4b588f-4d7d-438a-9d5a-a9ea00f1b7f7)

### CouponIssuance 는 어디에 ?
- 할인 쿠폰 발급은 Coupon 도메인에서 담당한다.
\+ 할인 쿠폰 발급은 Coupon 도메인에서 담당한다.
\+ 할인 쿠폰 생성 시 Coupon 과 Customer 가 null 이 아니어야 한다.
\+ 할인 쿠폰 만료일이 발급일보다 이전이여야한다.
\+ 할인 쿠폰의 수량이 0일 때 발급 받을 수 없다.
<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
