### PR TITLE
[feat] querydsl을 설정하여 동적쿼리를 생성할 수 있다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle,java,intellij
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,35 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//QueryDsl
+	// QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 생성 위치
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(generated)
+}
+
+task cleanGenerated(type: Delete) {
+	delete generated
+}
+
+clean.dependsOn cleanGenerated
+compileJava.dependsOn clean
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += "$projectDir/build/generated"
 }

--- a/src/main/java/camp/woowak/lab/web/config/QuerydslConfig.java
+++ b/src/main/java/camp/woowak/lab/web/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package camp.woowak.lab.web.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #97 

- 조회에 동적 쿼리가 필요하기 때문에 QueryDsl 5.0 버전을 설정

<br>

## 💡 다음 자료를 참고하면 좋아요.

- 혹시나 QEntity를 import하지 못한다면 intellij 의 캐시를 지워주시고, project structure 에서 /src/main/generated 폴더를 source 폴더로 등록해야합니다.

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
