### PR TITLE
[feat] 메뉴 카테고리를 조회할 수 있다

### DIFF
--- a/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
+++ b/src/main/java/camp/woowak/lab/web/api/store/StoreApiController.java
@@ -2,6 +2,9 @@ package camp.woowak.lab.web.api.store;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,10 +18,12 @@ import camp.woowak.lab.store.service.command.StoreMenuRegistrationCommand;
 import camp.woowak.lab.store.service.command.StoreRegistrationCommand;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.annotation.AuthenticationPrincipal;
+import camp.woowak.lab.web.dao.MenuDao;
 import camp.woowak.lab.web.dto.request.store.MenuCategoryRegistrationRequest;
 import camp.woowak.lab.web.dto.request.store.StoreMenuRegistrationRequest;
 import camp.woowak.lab.web.dto.request.store.StoreRegistrationRequest;
 import camp.woowak.lab.web.dto.response.store.MenuCategoryRegistrationResponse;
+import camp.woowak.lab.web.dto.response.store.MenuCategoryResponse;
 import camp.woowak.lab.web.dto.response.store.StoreMenuRegistrationResponse;
 import camp.woowak.lab.web.dto.response.store.StoreRegistrationResponse;
 import jakarta.validation.Valid;
@@ -31,6 +36,7 @@ public class StoreApiController {
 	private final StoreRegistrationService storeRegistrationService;
 	private final StoreMenuRegistrationService storeMenuRegistrationService;
 	private final MenuCategoryRegistrationService menuCategoryRegistrationService;
+	private final MenuDao menuDao;
 
 	@PostMapping("/stores")
 	public StoreRegistrationResponse storeRegistration(@AuthenticationPrincipal final LoginVendor loginVendor,
@@ -66,10 +72,15 @@ public class StoreApiController {
 		return new StoreMenuRegistrationResponse(menuIds);
 	}
 
+	@GetMapping("/stores/{storeId}/category")
+	public Page<MenuCategoryResponse> findAllMenuCategory(@PathVariable Long storeId, Pageable pageable) {
+		return menuDao.findAllCategoriesByStoreId(storeId, pageable);
+	}
+
 	@PostMapping("/stores/{storeId}/category")
-	public MenuCategoryRegistrationResponse storeCategoryRegistration(@AuthenticationPrincipal LoginVendor loginVendor,
-																	  @PathVariable Long storeId,
-																	  @Valid @RequestBody MenuCategoryRegistrationRequest request) {
+	public MenuCategoryRegistrationResponse registerMenuCategory(@AuthenticationPrincipal LoginVendor loginVendor,
+																 @PathVariable Long storeId,
+																 @Valid @RequestBody MenuCategoryRegistrationRequest request) {
 		MenuCategoryRegistrationCommand command =
 			new MenuCategoryRegistrationCommand(loginVendor.getId(), storeId, request.name());
 		Long registeredId = menuCategoryRegistrationService.register(command);

--- a/src/main/java/camp/woowak/lab/web/dao/MenuDao.java
+++ b/src/main/java/camp/woowak/lab/web/dao/MenuDao.java
@@ -1,0 +1,11 @@
+package camp.woowak.lab.web.dao;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import camp.woowak.lab.web.dto.response.store.MenuCategoryResponse;
+
+public interface MenuDao {
+
+	Page<MenuCategoryResponse> findAllCategoriesByStoreId(Long storeId, Pageable pageable);
+}

--- a/src/main/java/camp/woowak/lab/web/dao/QueryDslMenuDao.java
+++ b/src/main/java/camp/woowak/lab/web/dao/QueryDslMenuDao.java
@@ -1,0 +1,56 @@
+package camp.woowak.lab.web.dao;
+
+import static camp.woowak.lab.menu.domain.QMenuCategory.*;
+import static camp.woowak.lab.store.domain.QStore.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import camp.woowak.lab.web.dto.response.store.MenuCategoryResponse;
+
+@Repository
+public class QueryDslMenuDao implements MenuDao {
+	private final JPAQueryFactory queryFactory;
+
+	public QueryDslMenuDao(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public Page<MenuCategoryResponse> findAllCategoriesByStoreId(Long storeId, Pageable pageable) {
+
+		List<MenuCategoryResponse> content = queryFactory
+			.select(Projections.constructor(MenuCategoryResponse.class,
+				menuCategory.id,
+				menuCategory.name))
+			.from(menuCategory)
+			.where(
+				eqStoreId(storeId)
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(menuCategory.count())
+			.from(menuCategory)
+			.where(
+				eqStoreId(storeId)
+			);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	private BooleanExpression eqStoreId(Long storeId) {
+		return store.id.eq(storeId);
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/dto/response/store/MenuCategoryResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/store/MenuCategoryResponse.java
@@ -1,0 +1,17 @@
+package camp.woowak.lab.web.dto.response.store;
+
+import lombok.Getter;
+
+@Getter
+public class MenuCategoryResponse {
+	private long id;
+	private String name;
+
+	public MenuCategoryResponse() {
+	}
+
+	public MenuCategoryResponse(long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/api/store/StoreApiControllerTest.java
+++ b/src/test/java/camp/woowak/lab/web/api/store/StoreApiControllerTest.java
@@ -2,9 +2,11 @@ package camp.woowak.lab.web.api.store;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -17,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -41,8 +45,10 @@ import camp.woowak.lab.web.authentication.AuthenticationErrorCode;
 import camp.woowak.lab.web.authentication.LoginVendor;
 import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
 import camp.woowak.lab.web.authentication.PasswordEncoder;
+import camp.woowak.lab.web.dao.MenuDao;
 import camp.woowak.lab.web.dto.request.store.MenuCategoryRegistrationRequest;
 import camp.woowak.lab.web.dto.request.store.StoreRegistrationRequest;
+import camp.woowak.lab.web.dto.response.store.MenuCategoryResponse;
 import camp.woowak.lab.web.resolver.session.SessionConst;
 import camp.woowak.lab.web.resolver.session.SessionVendorArgumentResolver;
 
@@ -64,6 +70,9 @@ class StoreApiControllerTest {
 
 	@MockBean
 	private VendorRepository vendorRepository;
+
+	@MockBean
+	private MenuDao menuDao;
 
 	@MockBean
 	private SessionVendorArgumentResolver sessionVendorArgumentResolver;
@@ -244,6 +253,38 @@ class StoreApiControllerTest {
 				.andExpect(status().isForbidden());
 
 			verify(menuCategoryRegistrationService).register(any(MenuCategoryRegistrationCommand.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 카테고리 생성: GET /stores/{storeId}/category")
+	class MenuCategoryQuery {
+		@Test
+		@DisplayName("[Success] 200 OK")
+		void success() throws Exception {
+			// given
+			long fakeStoreId = new Random().nextLong();
+			List<MenuCategoryResponse> queryResult = List.of(
+				new MenuCategoryResponse(1L, "Category 1"), new MenuCategoryResponse(2L, "Category 2"),
+				new MenuCategoryResponse(3L, "Category 3"));
+
+			// when
+			PageRequest pageRequest = PageRequest.of(0, 3);
+			when(menuDao.findAllCategoriesByStoreId(any(), any())).thenReturn(
+				new PageImpl<>(queryResult, pageRequest, 10));
+
+			// then
+			mockMvc.perform(get("/stores/{storedId}/category", fakeStoreId)
+					.param("page", "0")
+					.param("size", "3"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.totalElements").value(10))
+				.andExpect(jsonPath("$.data.totalPages").value(4))
+				.andExpect(jsonPath("$.data.size").value(3))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andDo(print());
+
+			verify(menuDao).findAllCategoriesByStoreId(fakeStoreId, pageRequest);
 		}
 	}
 

--- a/src/test/java/camp/woowak/lab/web/dao/QueryDslMenuDaoTest.java
+++ b/src/test/java/camp/woowak/lab/web/dao/QueryDslMenuDaoTest.java
@@ -1,0 +1,97 @@
+package camp.woowak.lab.web.dao;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import camp.woowak.lab.infra.date.DateTimeProvider;
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.menu.repository.MenuCategoryRepository;
+import camp.woowak.lab.payaccount.domain.PayAccount;
+import camp.woowak.lab.payaccount.repository.PayAccountRepository;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.domain.StoreCategory;
+import camp.woowak.lab.store.repository.StoreCategoryRepository;
+import camp.woowak.lab.store.repository.StoreRepository;
+import camp.woowak.lab.vendor.domain.Vendor;
+import camp.woowak.lab.vendor.repository.VendorRepository;
+import camp.woowak.lab.web.authentication.NoOpPasswordEncoder;
+import camp.woowak.lab.web.dto.response.store.MenuCategoryResponse;
+
+@SpringBootTest
+@Transactional
+class QueryDslMenuDaoTest {
+
+	@Autowired
+	private QueryDslMenuDao queryDslMenuDao;
+
+	@Autowired
+	private StoreRepository storeRepository;
+
+	@Autowired
+	private MenuCategoryRepository menuCategoryRepository;
+
+	@Autowired
+	private VendorRepository vendorRepository;
+
+	@Autowired
+	private PayAccountRepository payAccountRepository;
+
+	@Autowired
+	private StoreCategoryRepository storeCategoryRepository;
+
+	private Store testStore;
+
+	@BeforeEach
+	void setUp() {
+		PayAccount testAccount = payAccountRepository.save(new PayAccount());
+		Vendor testVendor = vendorRepository.save(
+			new Vendor("Test Vendor", "TestEmail@email.com", "TestPassword", "010-0000-0000", testAccount,
+				new NoOpPasswordEncoder()));
+		StoreCategory testCategory = storeCategoryRepository.save(new StoreCategory("TestCategory"));
+		// 테스트용 Store 생성
+		DateTimeProvider fixedTimeProvider = () -> LocalDateTime.of(2024, 8, 24, 1, 0, 0);
+		testStore = storeRepository.save(
+			new Store(testVendor, testCategory, "Test Store", "송파", "010-1234-5678", 18000,
+				fixedTimeProvider.now(), fixedTimeProvider.now().plusHours(10)));
+
+		// 테스트용 MenuCategory 생성
+		menuCategoryRepository.saveAll(List.of(
+			new MenuCategory(testStore, "Category 1"),
+			new MenuCategory(testStore, "Category 2"),
+			new MenuCategory(testStore, "Category 3")
+		));
+	}
+
+	@Nested
+	@DisplayName("findAllCategoriesByStoreId는")
+	class FindAllCategoriesByStoreIdIs {
+		@Test
+		@DisplayName("Page<MenuCategoryResponse>를 반환한다.")
+		void findAllCategoriesByStoreId_ShouldReturnPagedMenuCategoryResponses() {
+			// Given
+			PageRequest pageable = PageRequest.of(0, 10);
+
+			// When
+			Page<MenuCategoryResponse> result = queryDslMenuDao.findAllCategoriesByStoreId(testStore.getId(), pageable);
+
+			// Then
+			assertThat(result.getContent()).hasSize(3);
+			assertThat(result.getContent().get(0).getName()).isEqualTo("Category 1");
+			assertThat(result.getContent().get(1).getName()).isEqualTo("Category 2");
+			assertThat(result.getContent().get(2).getName()).isEqualTo("Category 3");
+			assertThat(result.getTotalElements()).isEqualTo(3L);
+		}
+	}
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link 
- #109 
- 가게에서 만든 메뉴 카테고리를 조회하는 기능입니다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- MenuDao를 인터페이스로 만들고 QueryDslMenuDao를 구현체로 사용하고 있습니다.

<br>

## 💡 이런 고민을 했어요.

- 메뉴를 조회하는 기능도 MenuDao로 구현하면 좋겠다

<br>


## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] wiki를 수정했습니다.
