### PR TITLE
[fix] Store 도메인의 isopen 메서드 오류 수정

### DIFF
--- a/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
+++ b/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
@@ -4,24 +4,48 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class StoreTime {
 
 	@Column(nullable = false)
-	private LocalDateTime startTime;
-
+	private int startHour;
 	@Column(nullable = false)
-	private LocalDateTime endTime;
+	private int startMinute;
+	@Column(nullable = false)
+	private int endHour;
+	@Column(nullable = false)
+	private int endMinute;
+	@Transient
+	private boolean overDay;
 
 	public StoreTime(final LocalDateTime startTime, final LocalDateTime endTime) {
-		this.startTime = startTime;
-		this.endTime = endTime;
+		this.startHour = startTime.getHour();
+		this.startMinute = startTime.getMinute();
+
+		this.endHour = endTime.getHour();
+		this.endMinute = endTime.getMinute();
+
+		this.overDay = startTime.toLocalDate().isBefore(endTime.toLocalDate());
 	}
 
+	public LocalDateTime getStartTime() {
+		LocalDateTime now = LocalDateTime.now();
+		int year = now.getYear();
+		int month = now.getMonthValue();
+		int day = now.getDayOfMonth();
+		return LocalDateTime.of(year, month, day, startHour, startMinute, 0, 0);
+	}
+
+	public LocalDateTime getEndTime() {
+		LocalDateTime now = LocalDateTime.now().plusDays(overDay ? 1 : 0);
+		int year = now.getYear();
+		int month = now.getMonthValue();
+		int day = now.getDayOfMonth();
+		return LocalDateTime.of(year, month, day, endHour, endMinute, 0, 0);
+	}
 }

--- a/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
+++ b/src/main/java/camp/woowak/lab/store/domain/StoreTime.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -20,8 +19,6 @@ public class StoreTime {
 	private int endHour;
 	@Column(nullable = false)
 	private int endMinute;
-	@Transient
-	private boolean overDay;
 
 	public StoreTime(final LocalDateTime startTime, final LocalDateTime endTime) {
 		this.startHour = startTime.getHour();
@@ -29,8 +26,6 @@ public class StoreTime {
 
 		this.endHour = endTime.getHour();
 		this.endMinute = endTime.getMinute();
-
-		this.overDay = startTime.toLocalDate().isBefore(endTime.toLocalDate());
 	}
 
 	public LocalDateTime getStartTime() {
@@ -42,10 +37,17 @@ public class StoreTime {
 	}
 
 	public LocalDateTime getEndTime() {
-		LocalDateTime now = LocalDateTime.now().plusDays(overDay ? 1 : 0);
+		LocalDateTime startTime = getStartTime();
+
+		LocalDateTime now = LocalDateTime.now();
 		int year = now.getYear();
 		int month = now.getMonthValue();
 		int day = now.getDayOfMonth();
-		return LocalDateTime.of(year, month, day, endHour, endMinute, 0, 0);
+		LocalDateTime endTime = LocalDateTime.of(year, month, day, endHour, endMinute, 0, 0);
+		if (endTime.isBefore(startTime)) {
+			endTime = endTime.plusDays(1);
+		}
+
+		return endTime;
 	}
 }

--- a/src/test/java/camp/woowak/lab/store/domain/StoreTest.java
+++ b/src/test/java/camp/woowak/lab/store/domain/StoreTest.java
@@ -302,6 +302,61 @@ class StoreTest {
 
 		}
 
+		@Nested
+		@DisplayName("isOpen 메서드는")
+		class IsOpen {
+			private Vendor vendor = createVendor();
+			private StoreCategory storeCategory = createStoreCategory();
+
+			@Test
+			@DisplayName("오픈시간 이내의 시간이면 true이다.")
+			void success() {
+				//given
+				LocalDateTime startTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+				LocalDateTime endTime = LocalDateTime.now().plusMinutes(10).withSecond(0).withNano(0);
+				Store store = createStore(startTime, endTime);
+
+				//when
+				boolean open = store.isOpen();
+
+				//then
+				assertThat(open).isTrue();
+			}
+
+			@Test
+			@DisplayName("오픈시간 이전이면 false이다.")
+			void failWhenBeforeOpen() {
+				//given
+				LocalDateTime startTime = LocalDateTime.now().minusMinutes(30).withSecond(0).withNano(0);
+				LocalDateTime endTime = LocalDateTime.now().minusMinutes(10).withSecond(0).withNano(0);
+				Store store = createStore(startTime, endTime);
+
+				//when
+				boolean open = store.isOpen();
+
+				//then
+				assertThat(open).isFalse();
+			}
+
+			@Test
+			@DisplayName("폐점시간 이후면 false이다.")
+			void failWhenAfterClose() {
+				//given
+				LocalDateTime startTime = LocalDateTime.now().plusMinutes(10).withSecond(0).withNano(0);
+				LocalDateTime endTime = LocalDateTime.now().plusMinutes(30).withSecond(0).withNano(0);
+				Store store = createStore(startTime, endTime);
+
+				//when
+				boolean open = store.isOpen();
+
+				//then
+				assertThat(open).isFalse();
+			}
+
+			private Store createStore(LocalDateTime startTime, LocalDateTime endTime) {
+				return new Store(vendor, storeCategory, "store1", "송파", "010-1111-2222", 8000, startTime, endTime);
+			}
+		}
 	}
 
 	private Vendor createVendor() {


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #84 

- Store를 등록할 때 입력받은 startTime과 endTime을 기준으로 isOpen을 진행하면 날짜가 바뀔경우 모두 close된 상태로 반환됨.
```
1. 등록을 2024.08.16 12:30:00 ~ 2024.08.16 15:00:00 으로 설정을 해둔 상태이다.
2. 만약 2024.08.17 13:00:00 에 isOpen을 호출하면 예상 결과는 true지만, 실행 결과는 false가 나올것이다.
```

따라서 startTime과 endTime을 받아 hour와 minute을 추출한 뒤, 메서드를 호출한 시점을 기준으로 hour와 minute을 이용해 open/close를 결정하도록 변경

<br>

## 💡 이런 고민을 했어요.

- 넘어가는 날짜 (ex 2024.08.20 23:00 ~ 2024.08.21 03:00) 와 같은 예외도 처리하기 위해 overDay라는 변수를 추가한 뒤, close시간을 호출할 때 overDay가 true라면 day를 1일 추가해서 return해준다.

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
