### PR TITLE
[fix] store 도메인의 isOpen 메서드 수정 못했던것 수정

### DIFF
--- a/src/main/java/camp/woowak/lab/store/domain/Store.java
+++ b/src/main/java/camp/woowak/lab/store/domain/Store.java
@@ -80,7 +80,7 @@ public class Store {
 
 		LocalDateTime now = LocalDateTime.now();
 
-		return (now.isEqual(openTime) || now.isAfter(openTime)) && now.isBefore(closeTime);
+		return openTime.isBefore(now) && now.isBefore(closeTime);
 	}
 
 	public String getStoreAddress() {


### PR DESCRIPTION
이전 PR에서 storeTime의 구조를 변경하면서 미처 변경하지 못한 도메인 수정

## 💡 다음 이슈를 해결했어요.

### Issue Link - #84 

- 이전 PR #117 에서 미처 수정하지 못한 store domain의 isOpen 메서드를 수정
<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
