### PR TITLE
[feat] redis 테스트 환경 구축

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //test-container
+	testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+	testImplementation "org.testcontainers:testcontainers:1.17.2"
+	testImplementation "org.testcontainers:junit-jupiter:1.17.2"
+
 	//QueryDsl
 	// QueryDsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/test/java/camp/woowak/lab/container/ContainerSettingTest.java
+++ b/src/test/java/camp/woowak/lab/container/ContainerSettingTest.java
@@ -1,0 +1,60 @@
+package camp.woowak.lab.container;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@Testcontainers
+@Import({ContainerSettingTest.TestConfigurationWithRedis.class})
+public class ContainerSettingTest {
+	@Container
+	private static final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
+		.withExposedPorts(6379);
+
+	@Autowired
+	private RedisTemplate<String,Object> redisTemplate;
+
+	@TestConfiguration
+	public static class TestConfigurationWithRedis{
+		@Bean
+		public RedisConnectionFactory redisConnectionFactory(){
+			int port = container.getFirstMappedPort();
+			String host = container.getHost();
+			return new LettuceConnectionFactory(host,port);
+		}
+
+		@Bean
+		public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+			RedisTemplate<String, Object> template = new RedisTemplate<>();
+			template.setConnectionFactory(redisConnectionFactory);
+
+			template.setKeySerializer(new StringRedisSerializer());
+			template.setValueSerializer(new StringRedisSerializer());
+
+			return template;
+		}
+	}
+
+	@Test
+	void testSimplePutAndGet(){
+		redisTemplate.opsForValue().set("key","value");
+
+		String o = (String)redisTemplate.opsForValue().get("key");
+
+		assertThat(o).isEqualTo("value");
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  application:
+    name: lab
+
+  datasource:
+    url: 'jdbc:h2:mem:lab'
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #129 

- 기능 고도화를 진행할 때 여러가지 미들웨어를 적용하며 테스트를 진행하기 위해 격리된 미들웨어 환경을 test-container로 구축

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- `ContainerSettingTest` : 테스트 컨테이너가 잘 구동되는지에 대한 테스트코드 겸 명세서입니다.

<br>

## 💡 이런 고민을 했어요.

-  test-container는 실제로 도커를 이용해서 미들웨어 환경을 구축한 뒤 테스트를 진행하기 때문에 매우 느립니다.
- 고작, redis 에 key,value를 저장하고, key로 value를 조회하는 테스트를 진행했는데 아래와 같이 300ms 정도 걸렸습니다.
<img width="271" alt="image" src="https://github.com/user-attachments/assets/b88d490c-7ef4-422a-82bc-73a81027b3c0">

- Embedded redis를 이용해서 테스트를 진행하면 빠르겠지만, 많은 오류와 최신 릴리즈의 부재로 시간이 많이 들고, 테스트 환경 구축에 많은 시간을 할애할 수 없기때문에 Reject 했습니다.
<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
