### PR TITLE
[feat] 카트를 조회할 수 있는 Dao를 Redis를 이용해서 구현

### DIFF
--- a/src/main/java/camp/woowak/lab/web/dao/cart/RedisCartDao.java
+++ b/src/main/java/camp/woowak/lab/web/dao/cart/RedisCartDao.java
@@ -1,0 +1,93 @@
+package camp.woowak.lab.web.dao.cart;
+
+import static camp.woowak.lab.menu.domain.QMenu.*;
+import static camp.woowak.lab.store.domain.QStore.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import camp.woowak.lab.cart.domain.Cart;
+import camp.woowak.lab.cart.repository.CartRepository;
+import camp.woowak.lab.web.dto.response.CartResponse;
+
+@Repository
+public class RedisCartDao implements CartDao {
+	private final CartRepository cartRepository;
+	private final JPAQueryFactory queryFactory;
+
+	public RedisCartDao(@Qualifier("inMemoryCartRepository") CartRepository cartRepository,
+						JPAQueryFactory queryFactory) {
+		this.cartRepository = cartRepository;
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public CartResponse findByCustomerId(UUID customerId) {
+		Optional<Cart> optionalCart = cartRepository.findByCustomerId(customerId.toString());
+		if (optionalCart.isEmpty()) {
+			return new CartResponse();
+		}
+		Cart cart = optionalCart.get();
+
+		if (cart.getCartItems().isEmpty()) {
+			return new CartResponse();
+		}
+
+		Long sId = cart.getCartItems().stream().findAny().get().getStoreId();
+		Map<Long, Integer> menuIdsCount = new HashMap<>();
+		Set<Long> menuIds = cart.getCartItems().stream()
+			.map((cartItem) -> {
+				int amount = cartItem.getAmount();
+				menuIdsCount.put(cartItem.getMenuId(), amount);
+				return cartItem.getMenuId();
+			})
+			.collect(Collectors.toSet());
+
+		List<Tuple> results = queryFactory
+			.select(
+				store.id,
+				store.name,
+				store.minOrderPrice,
+				menu.id,
+				menu.name,
+				menu.price,
+				menu.stockCount
+			)
+			.from(store)
+			.join(menu).on(menu.store.id.eq(store.id))
+			.where(store.id.eq(sId).and(menu.id.in(menuIds)))
+			.fetch();
+
+		if (results.isEmpty()) {
+			return null; // 또는 적절한 예외 처리
+		}
+
+		Tuple firstResult = results.get(0);
+		Long storeId = firstResult.get(store.id);
+		String storeName = firstResult.get(store.name);
+		Integer minOrderPrice = firstResult.get(store.minOrderPrice);
+
+		List<CartResponse.CartItemInfo> menuList = results.stream()
+			.map(tuple -> new CartResponse.CartItemInfo(
+				tuple.get(menu.id),
+				tuple.get(menu.name),
+				tuple.get(menu.price),
+				Integer.toUnsignedLong(menuIdsCount.get(tuple.get(menu.id))), // amount 대신 stockCount 사용
+				tuple.get(menu.stockCount)
+			))
+			.collect(Collectors.toList());
+
+		return new CartResponse(storeId, storeName, minOrderPrice, menuList);
+	}
+}

--- a/src/main/java/camp/woowak/lab/web/dto/response/CartResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/CartResponse.java
@@ -3,11 +3,24 @@ package camp.woowak.lab.web.dto.response;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Getter;
+
+@Getter
 public class CartResponse {
 	private Long storeId;
 	private String storeName;
 	private Integer minOrderPrice;
 	private List<CartItemInfo> menus = new ArrayList<>();
+
+	public CartResponse() {
+	}
+
+	public CartResponse(Long storId, String storeName, Integer minOrderPrice, List<CartItemInfo> menus) {
+		this.storeId = storId;
+		this.storeName = storeName;
+		this.minOrderPrice = minOrderPrice;
+		this.menus = menus;
+	}
 
 	public static class CartItemInfo {
 		private Long menuId;

--- a/src/main/java/camp/woowak/lab/web/dto/response/CartResponse.java
+++ b/src/main/java/camp/woowak/lab/web/dto/response/CartResponse.java
@@ -22,6 +22,7 @@ public class CartResponse {
 		this.menus = menus;
 	}
 
+	@Getter
 	public static class CartItemInfo {
 		private Long menuId;
 		private String menuName;

--- a/src/test/java/camp/woowak/lab/web/dao/cart/RedisCartDaoTest.java
+++ b/src/test/java/camp/woowak/lab/web/dao/cart/RedisCartDaoTest.java
@@ -1,0 +1,82 @@
+package camp.woowak.lab.web.dao.cart;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import camp.woowak.lab.cart.domain.Cart;
+import camp.woowak.lab.cart.repository.CartRepository;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.customer.repository.CustomerRepository;
+import camp.woowak.lab.menu.domain.Menu;
+import camp.woowak.lab.menu.domain.MenuCategory;
+import camp.woowak.lab.menu.repository.MenuCategoryRepository;
+import camp.woowak.lab.menu.repository.MenuRepository;
+import camp.woowak.lab.order.repository.OrderRepository;
+import camp.woowak.lab.payaccount.repository.PayAccountRepository;
+import camp.woowak.lab.store.domain.Store;
+import camp.woowak.lab.store.repository.StoreCategoryRepository;
+import camp.woowak.lab.store.repository.StoreRepository;
+import camp.woowak.lab.vendor.repository.VendorRepository;
+import camp.woowak.lab.web.dao.store.StoreDummiesFixture;
+import camp.woowak.lab.web.dto.response.CartResponse;
+
+@SpringBootTest
+class RedisCartDaoTest extends StoreDummiesFixture {
+	private final CartRepository cartRepository;
+	@Autowired
+	private RedisCartDao redisCartDao;
+
+	@Autowired
+	public RedisCartDaoTest(StoreRepository storeRepository,
+							StoreCategoryRepository storeCategoryRepository,
+							VendorRepository vendorRepository,
+							PayAccountRepository payAccountRepository,
+							OrderRepository orderRepository,
+							CustomerRepository customerRepository,
+							MenuRepository menuRepository,
+							MenuCategoryRepository menuCategoryRepository,
+							CartRepository cartRepository) {
+		super(storeRepository, storeCategoryRepository, vendorRepository, payAccountRepository, orderRepository,
+			  customerRepository, menuRepository, menuCategoryRepository);
+		this.cartRepository = cartRepository;
+	}
+
+	private Customer customer;
+	private Store store;
+	private MenuCategory menuCategory;
+	private List<Menu> menus;
+
+	@BeforeEach
+	void setUp() {
+		customer = createDummyCustomers(1).get(0);
+		store = createDummyStores(1).get(0);
+		menuCategory = createDummyMenuCategories(store,1).get(0);
+		menus = createDummyMenus(store,menuCategory,5);
+	}
+
+	@Test
+	@DisplayName("findByCustomerId 메서드는 장바구니에 담긴 메뉴의 아이템을 가져온다.")
+	void findByCustomerIdTest(){
+		//given
+		Cart cart = new Cart(customer.getId().toString());
+		cartRepository.save(cart);
+		menus.stream()
+			.forEach(cart::addMenu);
+		Cart save = cartRepository.save(cart);
+
+		//when
+		CartResponse response = redisCartDao.findByCustomerId(customer.getId());
+
+		//then
+		assertThat(response.getStoreId()).isEqualTo(store.getId());
+		assertThat(response.getStoreName()).isEqualTo(store.getName());
+		assertThat(response.getMinOrderPrice()).isEqualTo(store.getMinOrderPrice());
+	}
+}

--- a/src/test/java/camp/woowak/lab/web/dao/cart/RedisCartDaoTest.java
+++ b/src/test/java/camp/woowak/lab/web/dao/cart/RedisCartDaoTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import camp.woowak.lab.cart.domain.Cart;
 import camp.woowak.lab.cart.repository.CartRepository;
@@ -28,6 +29,7 @@ import camp.woowak.lab.web.dao.store.StoreDummiesFixture;
 import camp.woowak.lab.web.dto.response.CartResponse;
 
 @SpringBootTest
+@Transactional
 class RedisCartDaoTest extends StoreDummiesFixture {
 	private final CartRepository cartRepository;
 	@Autowired


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #127 

- RedisCartRepository와 queryDsl을 이용하여 현재 저장된 카트 리스트의 메뉴 정보들을 조회하는 dao 객체 생성

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
