### PR TITLE
[feat] 주문 시점에 배타락을 적용해서 문제를 해결

### DIFF
--- a/src/main/java/camp/woowak/lab/cart/persistence/jpa/repository/CartEntityRepository.java
+++ b/src/main/java/camp/woowak/lab/cart/persistence/jpa/repository/CartEntityRepository.java
@@ -4,9 +4,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import camp.woowak.lab.cart.persistence.jpa.entity.CartEntity;
+import jakarta.persistence.LockModeType;
 
 public interface CartEntityRepository extends JpaRepository<CartEntity, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<CartEntity> findByCustomerId(UUID customerId);
 }

--- a/src/test/java/camp/woowak/lab/cart/persistence/jpa/repository/JpaCartRepositoryTest.java
+++ b/src/test/java/camp/woowak/lab/cart/persistence/jpa/repository/JpaCartRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import camp.woowak.lab.cart.domain.Cart;
 import camp.woowak.lab.cart.repository.CartRepository;
@@ -24,6 +25,9 @@ import camp.woowak.lab.cart.repository.CartRepository;
 @DataJpaTest
 @Transactional
 class JpaCartRepositoryTest {
+	@Autowired
+	private TransactionTemplate transactionTemplate;
+
 	@Autowired
 	private CartRepository cartRepository;
 	@Autowired
@@ -51,7 +55,8 @@ class JpaCartRepositoryTest {
 		@Test
 		@DisplayName("저장된 CartEntity가 있는 경우")
 		void returnOptionalWhenCartEntityIsFound() {
-			Optional<Cart> findCart = cartRepository.findByCustomerId(fakeCustomerId.toString());
+			Optional<Cart> findCart = transactionTemplate.execute(
+				(status) -> cartRepository.findByCustomerId(fakeCustomerId.toString()));
 			assertThat(findCart.isPresent()).isTrue();
 			assertThat(findCart.get().getCustomerId()).isEqualTo(fakeCustomerId.toString());
 		}
@@ -60,7 +65,8 @@ class JpaCartRepositoryTest {
 		@DisplayName("저장된 CartEntity가 없는 경우")
 		void returnEmptyOptionalWhenCartEntityIsNotFound() {
 			cartEntityRepository.deleteAll();
-			Optional<Cart> findCart = cartRepository.findByCustomerId(fakeCustomerId.toString());
+			Optional<Cart> findCart = transactionTemplate.execute(
+				(status) -> cartRepository.findByCustomerId(fakeCustomerId.toString()));
 			assertThat(findCart.isPresent()).isFalse();
 		}
 	}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link - #118 

- 중복결제를 방지하기 위해 주문/결제 진입지점인 Cart 조회에 "배타락"을 건다.

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- `CartEntityRepository.findByCustomerId`에 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 적용

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] wiki를 수정했습니다.
