### PR TITLE
[기능] order 도메인 구조 수정

### DIFF
--- a/src/main/java/camp/woowak/lab/order/domain/Order.java
+++ b/src/main/java/camp/woowak/lab/order/domain/Order.java
@@ -45,8 +45,7 @@ public class Order {
 
 	private LocalDateTime createdAt;
 
-	public Order(Customer requester
-		, Store store, List<OrderItem> orderItems, LocalDateTime createdAt) {
+	public Order(Customer requester, Store store, List<OrderItem> orderItems, LocalDateTime createdAt) {
 		this.requester = requester;
 		this.store = store;
 		this.orderItems = orderItems;

--- a/src/main/java/camp/woowak/lab/order/domain/Order.java
+++ b/src/main/java/camp/woowak/lab/order/domain/Order.java
@@ -5,18 +5,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import camp.woowak.lab.cart.domain.vo.CartItem;
 import camp.woowak.lab.customer.domain.Customer;
-import camp.woowak.lab.menu.exception.NotEnoughStockException;
 import camp.woowak.lab.order.domain.vo.OrderItem;
-import camp.woowak.lab.order.exception.EmptyCartException;
-import camp.woowak.lab.order.exception.MinimumOrderPriceNotMetException;
-import camp.woowak.lab.order.exception.MultiStoreOrderException;
-import camp.woowak.lab.order.exception.NotFoundMenuException;
-import camp.woowak.lab.payaccount.exception.InsufficientBalanceException;
-import camp.woowak.lab.payaccount.exception.NotFoundAccountException;
 import camp.woowak.lab.store.domain.Store;
-import camp.woowak.lab.store.exception.NotFoundStoreException;
 import camp.woowak.lab.vendor.domain.Vendor;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
@@ -54,37 +45,12 @@ public class Order {
 
 	private LocalDateTime createdAt;
 
-	/**
-	 * @throws EmptyCartException 카트가 비어 있는 경우
-	 * @throws NotFoundStoreException 가게가 조회되지 않는 경우
-	 * @throws MultiStoreOrderException 여러 가게의 메뉴를 주문한 경우
-	 * @throws NotEnoughStockException 메뉴의 재고가 부족한 경우
-	 * @throws NotFoundMenuException 주문한 메뉴가 조회되지 않는 경우
-	 * @throws MinimumOrderPriceNotMetException 가게의 최소 주문금액보다 적은 금액을 주문한 경우
-	 * @throws NotFoundAccountException 구매자의 계좌가 조회되지 않는 경우
-	 * @throws InsufficientBalanceException 구매자의 계좌에 잔액이 충분하지 않은 경우
-	 */
-	public Order(Customer requester, List<CartItem> cartItems,
-				 SingleStoreOrderValidator singleStoreOrderValidator,
-				 StockRequester stockRequester, PriceChecker priceChecker, WithdrawPointService withdrawPointService,
-				 LocalDateTime createdAt) {
-		Store store = singleStoreOrderValidator.check(cartItems);
-
-		List<CartItem> stockDecreaseSuccessCartItems = null;
-		try {
-			stockDecreaseSuccessCartItems = stockRequester.request(cartItems);
-			List<OrderItem> orderItems = priceChecker.check(store, cartItems);
-			withdrawPointService.withdraw(requester, orderItems);
-			this.requester = requester;
-			this.store = store;
-			this.orderItems = orderItems;
-			this.createdAt = createdAt;
-		} catch (Exception e) {
-			if (stockDecreaseSuccessCartItems != null) {
-				stockRequester.rollback(stockDecreaseSuccessCartItems);
-			}
-			throw e;
-		}
+	public Order(Customer requester
+		, Store store, List<OrderItem> orderItems, LocalDateTime createdAt) {
+		this.requester = requester;
+		this.store = store;
+		this.orderItems = orderItems;
+		this.createdAt = createdAt;
 	}
 
 	public Customer getRequester() {

--- a/src/main/java/camp/woowak/lab/order/domain/OrderFactory.java
+++ b/src/main/java/camp/woowak/lab/order/domain/OrderFactory.java
@@ -1,0 +1,49 @@
+package camp.woowak.lab.order.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import camp.woowak.lab.cart.domain.vo.CartItem;
+import camp.woowak.lab.customer.domain.Customer;
+import camp.woowak.lab.infra.date.DateTimeProvider;
+import camp.woowak.lab.order.domain.vo.OrderItem;
+import camp.woowak.lab.store.domain.Store;
+
+@Component
+public class OrderFactory {
+	private final SingleStoreOrderValidator singleStoreOrderValidator;
+	private final StockRequester stockRequester;
+	private final PriceChecker priceChecker;
+	private final WithdrawPointService withdrawPointService;
+	private final DateTimeProvider dateTimeProvider;
+
+	public OrderFactory(SingleStoreOrderValidator singleStoreOrderValidator,
+						StockRequester stockRequester,
+						PriceChecker priceChecker,
+						WithdrawPointService withdrawPointService, DateTimeProvider dateTimeProvider) {
+		this.singleStoreOrderValidator = singleStoreOrderValidator;
+		this.stockRequester = stockRequester;
+		this.priceChecker = priceChecker;
+		this.withdrawPointService = withdrawPointService;
+		this.dateTimeProvider = dateTimeProvider;
+	}
+
+	public Order createOrder(Customer requester, List<CartItem> cartItems) {
+		Store store = singleStoreOrderValidator.check(cartItems);
+
+		List<CartItem> stockDecreaseSuccessCartItems = null;
+		try {
+			stockDecreaseSuccessCartItems = stockRequester.request(cartItems);
+			List<OrderItem> orderItems = priceChecker.check(store, cartItems);
+			withdrawPointService.withdraw(requester, orderItems);
+
+			return new Order(requester, store, orderItems, dateTimeProvider.now());
+		} catch (Exception e) {
+			if (stockDecreaseSuccessCartItems != null) {
+				stockRequester.rollback(stockDecreaseSuccessCartItems);
+			}
+			throw e;
+		}
+	}
+}

--- a/src/main/java/camp/woowak/lab/order/service/OrderCreationService.java
+++ b/src/main/java/camp/woowak/lab/order/service/OrderCreationService.java
@@ -12,13 +12,9 @@ import camp.woowak.lab.cart.repository.CartRepository;
 import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.customer.repository.CustomerRepository;
 import camp.woowak.lab.infra.aop.DistributedLock;
-import camp.woowak.lab.infra.date.DateTimeProvider;
 import camp.woowak.lab.menu.exception.NotEnoughStockException;
 import camp.woowak.lab.order.domain.Order;
-import camp.woowak.lab.order.domain.PriceChecker;
-import camp.woowak.lab.order.domain.SingleStoreOrderValidator;
-import camp.woowak.lab.order.domain.StockRequester;
-import camp.woowak.lab.order.domain.WithdrawPointService;
+import camp.woowak.lab.order.domain.OrderFactory;
 import camp.woowak.lab.order.exception.DuplicatedOrderException;
 import camp.woowak.lab.order.exception.EmptyCartException;
 import camp.woowak.lab.order.exception.MinimumOrderPriceNotMetException;
@@ -41,13 +37,9 @@ public class OrderCreationService {
 	private final OrderRepository orderRepository;
 	private final CartRepository cartRepository;
 	private final CustomerRepository customerRepository;
-	private final SingleStoreOrderValidator singleStoreOrderValidator;
-	private final StockRequester stockRequester;
-	private final WithdrawPointService withdrawPointService;
-	private final PriceChecker priceChecker;
 	private final OrderPaymentRepository orderPaymentRepository;
 
-	private final DateTimeProvider dateTimeProvider;
+	private final OrderFactory orderFactory;
 
 	/**
 	 * @throws EmptyCartException               카트가 비어 있는 경우
@@ -68,8 +60,7 @@ public class OrderCreationService {
 		List<CartItem> cartItems = cart.getCartItems();
 
 		Order savedOrder = orderRepository.save(
-			new Order(requester, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, dateTimeProvider.now())
+			orderFactory.createOrder(requester, cartItems)
 		);
 
 		saveOrderPayment(savedOrder);

--- a/src/test/java/camp/woowak/lab/order/domain/OrderTest.java
+++ b/src/test/java/camp/woowak/lab/order/domain/OrderTest.java
@@ -23,6 +23,7 @@ class OrderTest {
 	private PriceChecker priceChecker;
 	private WithdrawPointService withdrawPointService;
 	private final DateTimeProvider fixedDateTime = () -> LocalDateTime.of(2024, 8, 18, 1, 30, 30);
+	private OrderFactory orderFactory;
 
 	@BeforeEach
 	void setUp() {
@@ -30,6 +31,9 @@ class OrderTest {
 		stockRequester = mock(StockRequester.class);
 		priceChecker = mock(PriceChecker.class);
 		withdrawPointService = mock(WithdrawPointService.class);
+
+		orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker, withdrawPointService,
+			fixedDateTime);
 	}
 
 	@Test
@@ -50,8 +54,7 @@ class OrderTest {
 		when(withdrawPointService.withdraw(customer, orderItems)).thenReturn(orderItems);
 
 		// When
-		Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-			withdrawPointService, fixedDateTime.now());
+		Order order = orderFactory.createOrder(customer, cartItems);
 
 		// Then
 		assertEquals(orderItems, order.getOrderItems());
@@ -76,8 +79,7 @@ class OrderTest {
 
 		// When & Then
 		MultiStoreOrderException exception = assertThrows(MultiStoreOrderException.class, () -> {
-			new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, fixedDateTime.now());
+			orderFactory.createOrder(customer, cartItems);
 		});
 
 		assertEquals("다른 가게의 메뉴를 같이 주문할 수 없습니다.", exception.getMessage());

--- a/src/test/java/camp/woowak/lab/order/service/OrderCreationServiceTest.java
+++ b/src/test/java/camp/woowak/lab/order/service/OrderCreationServiceTest.java
@@ -22,6 +22,7 @@ import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.customer.repository.CustomerRepository;
 import camp.woowak.lab.infra.date.DateTimeProvider;
 import camp.woowak.lab.order.domain.Order;
+import camp.woowak.lab.order.domain.OrderFactory;
 import camp.woowak.lab.order.domain.PriceChecker;
 import camp.woowak.lab.order.domain.SingleStoreOrderValidator;
 import camp.woowak.lab.order.domain.StockRequester;
@@ -61,9 +62,13 @@ class OrderCreationServiceTest {
 
 	private final DateTimeProvider fixedDateTime = () -> LocalDateTime.of(2024, 8, 18, 1, 30, 30);
 
+	private OrderFactory orderFactory;
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
+		orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker, withdrawPointService,
+			fixedDateTime);
 	}
 
 	@Test
@@ -87,8 +92,7 @@ class OrderCreationServiceTest {
 		when(withdrawPointService.withdraw(any(Customer.class), anyList())).thenReturn(orderItems);
 
 		// When
-		Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-			withdrawPointService, fixedDateTime.now());
+		Order order = orderFactory.createOrder(customer, cartItems);
 
 		// Then
 		assertEquals(orderItems, order.getOrderItems());

--- a/src/test/java/camp/woowak/lab/payment/domain/OrderPaymentTest.java
+++ b/src/test/java/camp/woowak/lab/payment/domain/OrderPaymentTest.java
@@ -19,6 +19,7 @@ import camp.woowak.lab.customer.domain.Customer;
 import camp.woowak.lab.menu.domain.Menu;
 import camp.woowak.lab.menu.domain.MenuCategory;
 import camp.woowak.lab.order.domain.Order;
+import camp.woowak.lab.order.domain.OrderFactory;
 import camp.woowak.lab.order.domain.PriceChecker;
 import camp.woowak.lab.order.domain.SingleStoreOrderValidator;
 import camp.woowak.lab.order.domain.StockRequester;
@@ -57,6 +58,8 @@ class OrderPaymentTest {
 
 	@Mock
 	WithdrawPointService withdrawPointService;
+
+	private OrderFactory orderFactory;
 
 	@Nested
 	@DisplayName("총 주문 금액을 계산하는 기능은")
@@ -103,8 +106,12 @@ class OrderPaymentTest {
 			given(priceChecker.check(store, cartItems)).willReturn(orderItems);
 
 			LocalDateTime now = LocalDateTime.now();
-			Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, now);
+
+			orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker,
+				withdrawPointService,
+				() -> now);
+
+			Order order = orderFactory.createOrder(customer, cartItems);
 
 			OrderPayment orderPayment = new OrderPayment(order, customer, vendor, OrderPaymentStatus.ORDER_SUCCESS,
 				now);
@@ -139,8 +146,12 @@ class OrderPaymentTest {
 			given(priceChecker.check(store, cartItems)).willReturn(orderItems);
 
 			LocalDateTime now = LocalDateTime.now();
-			Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, now);
+
+			orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker,
+				withdrawPointService,
+				() -> now);
+
+			Order order = orderFactory.createOrder(customer, cartItems);
 
 			OrderPayment orderPayment = new OrderPayment(order, customer, vendor, OrderPaymentStatus.ORDER_SUCCESS,
 				now);
@@ -160,7 +171,7 @@ class OrderPaymentTest {
 
 		@Test
 		@DisplayName("[Success] 정산 대상 Vendor가 수령자이고 상태가 ORDER_SUCCESS이면 예외가 발생하지 않는다.")
-		void test1() {
+		void ƒtest1() {
 			// given
 			customer = createCustomer(createPayAccount());
 			Vendor recipientVendor = createVendor(createPayAccount());
@@ -169,8 +180,13 @@ class OrderPaymentTest {
 			given(priceChecker.check(store, cartItems)).willReturn(orderItems);
 
 			LocalDateTime now = LocalDateTime.now();
-			Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, now);
+
+			orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker,
+				withdrawPointService,
+				() -> now);
+
+			Order order = orderFactory.createOrder(customer, cartItems);
+
 			OrderPayment orderPayment = new OrderPayment(order, customer, recipientVendor,
 				OrderPaymentStatus.ORDER_SUCCESS,
 				now);
@@ -190,8 +206,13 @@ class OrderPaymentTest {
 			given(priceChecker.check(store, cartItems)).willReturn(orderItems);
 
 			LocalDateTime now = LocalDateTime.now();
-			Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, now);
+
+			orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker,
+				withdrawPointService,
+				() -> now);
+
+			Order order = orderFactory.createOrder(customer, cartItems);
+
 			OrderPayment orderPayment = new OrderPayment(order, customer, recipientVendor,
 				OrderPaymentStatus.ORDER_SUCCESS, now);
 
@@ -210,8 +231,13 @@ class OrderPaymentTest {
 			given(priceChecker.check(store, cartItems)).willReturn(orderItems);
 
 			LocalDateTime now = LocalDateTime.now();
-			Order order = new Order(customer, cartItems, singleStoreOrderValidator, stockRequester, priceChecker,
-				withdrawPointService, now);
+
+			orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker,
+				withdrawPointService,
+				() -> now);
+			
+			Order order = orderFactory.createOrder(customer, cartItems);
+
 			OrderPayment orderPayment = new OrderPayment(order, customer, recipientVendor,
 				OrderPaymentStatus.SETTLEMENT_SUCCESS, now);
 

--- a/src/test/java/camp/woowak/lab/web/dao/order/QueryDslOrderDaoTest.java
+++ b/src/test/java/camp/woowak/lab/web/dao/order/QueryDslOrderDaoTest.java
@@ -28,6 +28,7 @@ import camp.woowak.lab.menu.domain.MenuCategory;
 import camp.woowak.lab.menu.repository.MenuCategoryRepository;
 import camp.woowak.lab.menu.repository.MenuRepository;
 import camp.woowak.lab.order.domain.Order;
+import camp.woowak.lab.order.domain.OrderFactory;
 import camp.woowak.lab.order.domain.PriceChecker;
 import camp.woowak.lab.order.domain.SingleStoreOrderValidator;
 import camp.woowak.lab.order.domain.StockRequester;
@@ -82,6 +83,8 @@ class QueryDslOrderDaoTest {
 
 	private Vendor vendor1;
 	private Vendor vendor2;
+
+	private OrderFactory orderFactory;
 
 	@BeforeEach
 	void setUp() {
@@ -161,8 +164,10 @@ class QueryDslOrderDaoTest {
 		when(priceChecker.check(any(Store.class), anyList())).thenReturn(orderItems);
 
 		DateTimeProvider fixedTime = () -> LocalDateTime.of(2024, 8, 24, 1, 0, 0);
-		Order order = new Order(customer, Collections.EMPTY_LIST, singleStoreOrderValidator, stockRequester,
-			priceChecker, withdrawPointService, fixedTime.now());
+		orderFactory = new OrderFactory(singleStoreOrderValidator, stockRequester, priceChecker, withdrawPointService,
+			fixedTime);
+		Order order = orderFactory.createOrder(customer, Collections.EMPTY_LIST);
+			
 		orderRepository.save(order);
 		return order;
 	}

--- a/src/test/java/camp/woowak/lab/web/dao/store/StoreDummiesFixture.java
+++ b/src/test/java/camp/woowak/lab/web/dao/store/StoreDummiesFixture.java
@@ -15,6 +15,7 @@ import camp.woowak.lab.menu.domain.MenuCategory;
 import camp.woowak.lab.menu.repository.MenuCategoryRepository;
 import camp.woowak.lab.menu.repository.MenuRepository;
 import camp.woowak.lab.order.domain.Order;
+import camp.woowak.lab.order.domain.OrderFactory;
 import camp.woowak.lab.order.domain.PriceChecker;
 import camp.woowak.lab.order.domain.SingleStoreOrderValidator;
 import camp.woowak.lab.order.domain.StockRequester;
@@ -103,12 +104,14 @@ public abstract class StoreDummiesFixture {
 		for (int i = 0; i < store.size(); i++) {
 			Store s = store.get(i);
 			SingleStoreOrderValidator singleStoreOrderValidator = new TestSingleStoreOrderValidator(s, storeRepository);
+
+			OrderFactory orderFactory = new OrderFactory(singleStoreOrderValidator,
+				new StockRequester(menuRepository, menuStockCacheService), new TestPriceChecker(menuRepository),
+				new TestWithdrawPointService(payAccountRepository), LocalDateTime::now);
 			for (int j = 0; j < orderCount[i]; j++) {
 				Customer customer = dummyCustomers.get(
 					new Random(System.currentTimeMillis()).nextInt(dummyCustomers.size()));
-				Order order = new Order(customer, new ArrayList<>(), singleStoreOrderValidator,
-					new StockRequester(menuRepository, menuStockCacheService), new TestPriceChecker(menuRepository),
-					new TestWithdrawPointService(payAccountRepository), LocalDateTime.now());
+				Order order = orderFactory.createOrder(customer, new ArrayList<>());
 				orders.add(order);
 			}
 		}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

### Issue Link 
- [ ] #128 

<br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

- OrderFactory.java
https://github.com/woowa-techcamp-2024/Team1-3K1K/blob/3bf99bc7dc1e9dc99922d8c7f836aaa96fde6775/src/main/java/camp/woowak/lab/order/domain/OrderFactory.java#L14-L48

<br>

## 💡 이런 고민을 했어요.

- Order 는 도메인으로서의 역할만 하도록 변경하고 기존 생성 로직을 분리하고 싶었음
- 의존성 주입을 OrderFactory 를 통해 진행하면서 테스트 작성이 조금 더 용이해짐

<br>

## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가했습니다.
- [x] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
